### PR TITLE
fix dir bug in onnx2om.sh

### DIFF
--- a/deploy/models_utils/conversion/onnx2om.sh
+++ b/deploy/models_utils/conversion/onnx2om.sh
@@ -13,6 +13,6 @@ python auto_gear.py --image_path=/xx/lsvt/images \
                     --rec_onnx_path=ch_ppocr_server_v2.0_rec_infer_argmax.onnx \
                     --rec_model_height=32 \
                     --soc_version=Ascend310P \
-                    --output_path=./lsvt_om_v2n &&
+                    --output_path=./lsvt_om_v2 &&
 python auto_select.py --rec_model_path=lsvt_om_v2/crnn
 popd


### PR DESCRIPTION
Thank you for your contribution to the MindOCR repo.
Before submitting this PR, please make sure:

- [x] You have read the [Contributing Guidelines on pull requests](https://github.com/mindspore-lab/mindcv/blob/main/CONTRIBUTING.md)
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved terminology
- [ ] You have added unit tests

## Motivation

When execute onnx2om.sh, the output dir should be the same for auto_gear.py and auto_select.py

## Test Plan

(How should this PR be tested? Do you require special setup to run the test or repro the fixed bug?)

## Related Issues and PRs
Issue #60 
