### PR TITLE
fix excessive memory usage that causes OOM

### DIFF
--- a/mindocr/data/det_dataset.py
+++ b/mindocr/data/det_dataset.py
@@ -73,7 +73,7 @@ class DetDataset(BaseDataset):
             raise ValueError('No transform pipeline is specified!')
 
         # prefetch the data keys, to fit GeneratorDataset
-        _data = self.data_list[0]
+        _data = self.data_list[0].copy()        # WARNING: shallow copy. Do deep copy if necessary.
         _data = run_transforms(_data, transforms=self.transforms)
         _available_keys = list(_data.keys())
 
@@ -90,7 +90,7 @@ class DetDataset(BaseDataset):
 
 
     def __getitem__(self, index):
-        data = self.data_list[index]
+        data = self.data_list[index].copy()     # WARNING: shallow copy. Do deep copy if necessary.
 
         # perform transformation on data
         try:


### PR DESCRIPTION
- [x] You have read the [Contributing Guidelines on pull requests](https://github.com/mindspore-lab/mindcv/blob/main/CONTRIBUTING.md)
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved terminology
- [ ] You have added unit tests

## Motivation

This fix prevents storing datasets in memory thus saving dozens or even hundreds GBs of RAM.