### PR TITLE
update label file format of inference

### DIFF
--- a/deploy/data_utils/preprocess/label_format_trans_lsvt.py
+++ b/deploy/data_utils/preprocess/label_format_trans_lsvt.py
@@ -1,10 +1,6 @@
-import os
-import json
-import shutil
 import argparse
-from tqdm import tqdm
-import numpy as np
-
+import json
+import os
 
 """
 ICDAR2019-LSVT
@@ -14,7 +10,7 @@ https://dataset-bj.cdn.bcebos.com/lsvt/train_full_images_0.tar.gz
 https://dataset-bj.cdn.bcebos.com/lsvt/train_full_images_1.tar.gz
 https://dataset-bj.cdn.bcebos.com/lsvt/train_full_labels.json
 
-(1) mkdir images && mkdir labels
+(1) mkdir images
 
 (2) unzip dataset file
 tar -zvxf ./train_full_images_0.tar.gz
@@ -23,36 +19,45 @@ mv train_full_images_0/* images
 mv train_full_images_1/* images
 
 (3) run
-python label_format_trans_lsvt.py --label_json_path=train_full_labels.json --output_path=labels
+python label_format_trans_lsvt.py --src_labels_path=train_full_labels.json --tgt_labels_path=labels.txt
 
 """
 
 
+def label_format_trans_lsvt(src_labels_path, tgt_labels_path):
+    '''
+    Format annotation to standard form for LSVT dataset.
+    '''
+    with open(src_labels_path) as f:
+        samples = json.load(f)
+
+    save_dict = {}
+
+    for filename, boxes in samples.items():
+        filename = filename + ".jpg"
+        save_dict[filename] = []
+        for box in boxes:
+            if box["illegibility"]:
+                continue
+            save_dict[filename].append({"transcription": box['transcription'], "points": box['points']})
+
+    with open(tgt_labels_path, 'w', encoding='utf-8') as f:
+        if not save_dict:
+            f.write('')
+        for name, res in save_dict.items():
+            content = name + '\t' + json.dumps(res, ensure_ascii=False) + "\n"
+            f.write(content)
+
+
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
-    parser.add_argument('--label_json_path', type=str, required=True)
-    parser.add_argument('--output_path', type=str, required=True)
+    parser.add_argument('--src_labels_path', type=str, required=True,
+                        help='Path of the labels json file, such as lsvt/train_full_labels.json.')
+    parser.add_argument('--tgt_labels_path', type=str, default="labels.txt", required=False,
+                        help='Path to save the converted annotation.')
     args = parser.parse_args()
 
-    label_path = args.label_json_path
+    if not os.path.isfile(args.src_labels_path):
+        raise ValueError(f"Please make sure that {args.src_labels_path} is a file.")
 
-    save_path = args.output_path
-    if os.path.exists(save_path):
-        shutil.rmtree(save_path)
-    os.makedirs(save_path, mode=0o750, exist_ok=True)
-    label_dict = {}
-    with open(label_path, 'r') as f:
-        label_dict.update(json.load(f))
-    for file_name in tqdm(label_dict):
-        write_list = []
-        for info in label_dict[file_name]:
-            rec_label = [info['transcription']]
-            det_label = np.array(info['points']).reshape(-1).tolist()
-            det_label = list(map(str, det_label))
-            combine_label = ','.join(det_label + rec_label)
-            write_list.append(combine_label)
-        split_name = (file_name.split('.')[0]).split('_')
-        save_name = split_name[0] + '_img_' + split_name[1]
-        with open(os.path.join(save_path, save_name + '.txt'), 'w', encoding='utf8') as f:
-            for item in write_list:
-                f.write("%s\n" % item)
+    label_format_trans_lsvt(args.src_labels_path, args.tgt_labels_path)

--- a/deploy/data_utils/preprocess/label_format_trans_rctw.py
+++ b/deploy/data_utils/preprocess/label_format_trans_rctw.py
@@ -1,39 +1,41 @@
+import argparse
+import json
 import os
-from tqdm import tqdm
-import shutil
+
 import numpy as np
 from shapely.geometry import Polygon
-import argparse
-
+from tqdm import tqdm
 
 """
 ICDAR2017-RCTW
 
 download link: https://rctw.vlrlab.net/dataset, Training images and annotations_v1.2(7.6G)
 
-(1) mkdir images && mkdir labels
+(1) mkdir images
 
 (2) unzip dataset file
 images：cat train_images.zip.* > train_images.zip && unzip train_images.zip
 labels: unzip train_gts.zip
 
 (3) run 
-python label_format_trans_rctw.py --src_labels_path=train_gts \
-                                  --src_images_path=train_images \
-                                  --tgt_labels_path=labels \
-                                  --tgt_images_path=images
+python label_format_trans_rctw.py --src_labels_path=train_gts --tgt_labels_path=labels.txt
 """
 
-def label_format_trans_rctw(src_labels_path, src_images_path, tgt_labels_path, tgt_images_path):
+
+def label_format_trans_rctw(src_labels_path, tgt_labels_path):
+    '''
+    Format annotation to standard form for RCTW-17 dataset.
+    '''
+    save_dict = {}
+
     for filename in tqdm(os.listdir(src_labels_path)):
-        src_image_filename = filename.replace("txt", "jpg")
-        tgt_image_filename = src_image_filename.replace("image", "gt")
-        src_image_filename = os.path.join(src_images_path, src_image_filename)
-        tgt_image_filename = os.path.join(tgt_images_path, tgt_image_filename)
-        assert os.path.exists(src_image_filename)
-        shutil.copyfile(src_image_filename, tgt_image_filename)
+        if not filename.endswith(".txt"):
+            continue
+
+        image_filename = filename.replace("txt", "jpg")
         src_label_filename = os.path.join(src_labels_path, filename)
-        output = []
+        save_dict[image_filename] = []
+
         with open(src_label_filename, encoding="utf-8-sig") as f:
             content = f.readlines()
             lines = [line.strip() for line in content]
@@ -43,28 +45,33 @@ def label_format_trans_rctw(src_labels_path, src_images_path, tgt_labels_path, t
                 if split_line[-2] == '1':
                     continue
 
-                if "," in split_line[-1]:
-                    text = text.replace(",", " ")
-
+                # check illegal polygon
                 points = [int(x) for x in split_line[:8]]
                 polygon = Polygon(np.array(points).reshape(4, 2)).convex_hull
-                if polygon.area == 0:
+                if polygon.area <= 0:
                     continue
 
                 text = split_line[-1].strip("\"")
-                output.append(','.join([*split_line[:8], text]))
 
-        output = [line + '\n' for line in output]
-        tgt_label_filename = os.path.join(tgt_labels_path, filename.replace("image", "gt_img"))
-        with open(tgt_label_filename, 'w', encoding='utf-8') as f:
-            f.writelines(output)
+                save_dict[image_filename].append({"transcription": text, "points": points})
+
+    with open(tgt_labels_path, 'w', encoding='utf-8') as f:
+        if not save_dict:
+            f.write('')
+        for name, res in save_dict.items():
+            content = name + '\t' + json.dumps(res, ensure_ascii=False) + "\n"
+            f.write(content)
+
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
-    parser.add_argument('--src_labels_path', type=str, required=True)
-    parser.add_argument('--src_images_path', type=str, required=True)
-    parser.add_argument('--tgt_labels_path', type=str, required=True)
-    parser.add_argument('--tgt_images_path', type=str, required=True)
-
+    parser.add_argument('--src_labels_path', type=str, required=True,
+                        help='Directory of the labels, such as rctw/train_gts.')
+    parser.add_argument('--tgt_labels_path', type=str, default="labels.txt", required=False,
+                        help='Path to save the converted annotation.')
     args = parser.parse_args()
-    label_format_trans_rctw(args.src_labels_path, args.src_images_path, args.tgt_labels_path, args.tgt_images_path)
+
+    if not os.path.isdir(args.src_labels_path):
+        raise ValueError(f"Please make sure that {args.src_labels_path} is a dir.")
+
+    label_format_trans_rctw(args.src_labels_path, args.tgt_labels_path)


### PR DESCRIPTION
Thank you for your contribution to the MindOCR repo.
Before submitting this PR, please make sure:

- [ ] You have read the [Contributing Guidelines on pull requests](https://github.com/mindspore-lab/mindcv/blob/main/CONTRIBUTING.md)
- [ ] Your code builds clean without any errors or warnings
- [ ] You are using approved terminology
- [ ] You have added unit tests

## Motivation

Unify the format of label files of inference.

```
xxx.jpg	[{"transcription": “some text”, "points": [x1, y1, x2, y2, ...x8, y8]}, ...]
...
```
points is clockwise.

**Need to integrate into tools/dataset_converters in the future.**

## Test Plan

(How should this PR be tested? Do you require special setup to run the test or repro the fixed bug?)

## Related Issues and PRs

(Is this PR part of a group of changes? Link the other relevant PRs and Issues here. Use https://help.github.com/en/articles/closing-issues-using-keywords for help on GitHub syntax)
