### PR TITLE
fix some import path for inference

### DIFF
--- a/deploy/mx_infer/framework/module_base.py
+++ b/deploy/mx_infer/framework/module_base.py
@@ -3,8 +3,8 @@ from abc import abstractmethod
 from ctypes import c_longdouble
 from multiprocessing import Manager
 
-from deploy.mx_infer.data_type import ProfilingData
-from deploy.mx_infer.utils import log
+from mx_infer.data_type import ProfilingData
+from mx_infer.utils import log
 from .module_data_type import ModuleInitArgs
 
 

--- a/deploy/mx_infer/framework/module_manager.py
+++ b/deploy/mx_infer/framework/module_manager.py
@@ -1,8 +1,8 @@
 from collections import defaultdict, namedtuple
 from multiprocessing import Queue, Process
 
-from deploy.mx_infer.processors import processor_initiator
-from deploy.mx_infer.utils import log
+from mx_infer.processors import processor_initiator
+from mx_infer.utils import log
 from .module_data_type import ModulesInfo, ModuleInitArgs
 
 OutputRegisterInfo = namedtuple('OutputRegisterInfo', ['pipeline_name', 'module_send', 'module_recv'])

--- a/deploy/mx_infer/infer_pipeline.py
+++ b/deploy/mx_infer/infer_pipeline.py
@@ -2,15 +2,14 @@ import os
 import sys
 
 __dir__ = os.path.dirname(os.path.abspath(__file__))
-sys.path.insert(0, os.path.abspath(os.path.join(__dir__, '../../')))
-sys.path.insert(0, os.path.abspath(os.path.join(__dir__, '../../mindocr')))
+sys.path.insert(0, os.path.abspath(os.path.join(__dir__, '../')))  # mx_infer path
+sys.path.insert(0, os.path.abspath(os.path.join(__dir__, '../..')))  # tools path
 
-from deploy.mx_infer.args import get_args
-import deploy.mx_infer.pipeline as pipeline
+from mx_infer import pipeline_args, pipeline
 
 
 def main():
-    args = get_args()
+    args = pipeline_args.get_args()
     pipeline.build_pipeline(args)
 
 

--- a/deploy/mx_infer/pipeline.py
+++ b/deploy/mx_infer/pipeline.py
@@ -5,10 +5,10 @@ from multiprocessing import Process, Queue
 
 import tqdm
 
-from deploy.mx_infer.data_type import StopSign
-from deploy.mx_infer.framework import ModuleDesc, ModuleConnectDesc, ModuleManager, SupportedTaskOrder
-from deploy.mx_infer.processors import MODEL_DICT
-from deploy.mx_infer.utils import log, profiling, safe_div, save_path_init, TASK_QUEUE_SIZE
+from mx_infer.data_type import StopSign
+from mx_infer.framework import ModuleDesc, ModuleConnectDesc, ModuleManager, SupportedTaskOrder
+from mx_infer.processors import MODEL_DICT
+from mx_infer.utils import log, profiling, safe_div, save_path_init, TASK_QUEUE_SIZE
 
 
 def image_sender(images_path, send_queue, show_progressbar):
@@ -144,9 +144,8 @@ def build_pipeline(args):
         If the guidelines above are not followed, the inference pipeline cannot be built. Check your args configurations.
 
     Example:
-    >>> from deploy.mx_infer.args import get_args
-    >>> import deploy.mx_infer.pipeline as pipeline
-    >>> args = get_args()
+    >>> from mx_infer import pipeline_args, pipeline
+    >>> args = pipeline_args.get_args()
     >>> pipeline.build_pipeline(args)
     """
 

--- a/deploy/mx_infer/pipeline_args.py
+++ b/deploy/mx_infer/pipeline_args.py
@@ -2,9 +2,9 @@ import argparse
 import itertools
 import os
 
-from deploy.mx_infer.framework.module_data_type import InferModelComb
-from deploy.mx_infer.processors import SUPPORT_DET_MODEL, SUPPORT_REC_MODEL
-from deploy.mx_infer.utils import log
+from mx_infer.framework import InferModelComb
+from mx_infer.processors import SUPPORT_DET_MODEL, SUPPORT_REC_MODEL
+from mx_infer.utils import log
 
 
 def str2bool(v):
@@ -23,7 +23,8 @@ def get_args():
     parser.add_argument('--device', type=str, default='Ascend', required=False,
                         choices=['Ascend'], help='Device type.')
     parser.add_argument('--device_id', type=int, default=0, required=False, help='Device id.')
-    parser.add_argument('--parallel_num', type=int, default=1, required=False, help='Number of parallel in each stage of pipeline parallelism.')
+    parser.add_argument('--parallel_num', type=int, default=1, required=False,
+                        help='Number of parallel in each stage of pipeline parallelism.')
     parser.add_argument('--precision_mode', type=str, default="fp32", choices=['fp16', 'fp32'], required=False,
                         help='Precision mode.')
     parser.add_argument('--det_algorithm', type=str, default='DBNet', choices=SUPPORT_DET_MODEL, required=False,

--- a/deploy/mx_infer/processors/__init__.py
+++ b/deploy/mx_infer/processors/__init__.py
@@ -1,11 +1,13 @@
 from sys import modules
 
-from deploy.mx_infer.framework import InferModelComb
-from deploy.mx_infer.utils import log
+from mx_infer.framework import InferModelComb
+from mx_infer.utils import log
+
 from .classification import CLSPreProcess, CLSInferProcess
 from .common import HandoutProcess, CollectProcess, DecodeProcess
 from .detection import DetPreProcess, DetInferProcess, DetPostProcess, SUPPORT_DET_MODEL
 from .recognition import RecPreProcess, RecInferProcess, RecPostProcess, SUPPORT_REC_MODEL
+
 
 DET_DESC = [('DetPreProcess', 1), ('DetInferProcess', 1), ('DetPostProcess', 1)]
 REC_DESC = [('RecPreProcess', 1), ('RecInferProcess', 1), ('RecPostProcess', 1)]

--- a/deploy/mx_infer/processors/classification/cls_infer_process.py
+++ b/deploy/mx_infer/processors/classification/cls_infer_process.py
@@ -4,8 +4,8 @@ import cv2
 import numpy as np
 from mindx.sdk import base, Tensor
 
-from deploy.mx_infer.framework import ModuleBase
-from deploy.mx_infer.utils import check_valid_file
+from mx_infer.framework import ModuleBase
+from mx_infer.utils import check_valid_file
 
 
 class CLSInferProcess(ModuleBase):

--- a/deploy/mx_infer/processors/classification/cls_pre_process.py
+++ b/deploy/mx_infer/processors/classification/cls_pre_process.py
@@ -5,9 +5,9 @@ import cv2
 import numpy as np
 from mindx.sdk import base
 
-from deploy.mx_infer.data_type.process_data import ProcessData
-from deploy.mx_infer.framework import ModuleBase
-from deploy.mx_infer.utils import get_batch_list_greedy, get_hw_of_img, safe_div, padding_with_cv, normalize, \
+from mx_infer.data_type import ProcessData
+from mx_infer.framework import ModuleBase
+from mx_infer.utils import get_batch_list_greedy, get_hw_of_img, safe_div, padding_with_cv, normalize, \
     to_chw_image, expand, padding_batch, bgr_to_gray, get_shape_info, \
     check_valid_file, NORMALIZE_MEAN, NORMALIZE_STD, NORMALIZE_SCALE
 

--- a/deploy/mx_infer/processors/common/collect_process.py
+++ b/deploy/mx_infer/processors/common/collect_process.py
@@ -6,9 +6,9 @@ from multiprocessing import Manager
 import cv2
 import numpy as np
 
-from deploy.mx_infer.data_type import StopData, ProcessData, ProfilingData
-from deploy.mx_infer.framework import ModuleBase, InferModelComb
-from deploy.mx_infer.utils import safe_list_writer, log
+from mx_infer.data_type import StopData, ProcessData, ProfilingData
+from mx_infer.framework import ModuleBase, InferModelComb
+from mx_infer.utils import safe_list_writer, log
 from tools.utils.visualize import VisMode, Visualization
 
 _RESULTS_SAVE_FILENAME = {

--- a/deploy/mx_infer/processors/common/decode_process.py
+++ b/deploy/mx_infer/processors/common/decode_process.py
@@ -1,5 +1,5 @@
-from deploy.mx_infer.framework.module_base import ModuleBase
-from deploy.mx_infer.utils import safe_img_read, get_hw_of_img
+from mx_infer.framework import ModuleBase
+from mx_infer.utils import safe_img_read, get_hw_of_img
 
 
 class DecodeProcess(ModuleBase):

--- a/deploy/mx_infer/processors/common/handout_process.py
+++ b/deploy/mx_infer/processors/common/handout_process.py
@@ -1,8 +1,8 @@
 import os
 
-from deploy.mx_infer.data_type import ProcessData, StopData, StopSign
-from deploy.mx_infer.framework.module_base import ModuleBase
-from deploy.mx_infer.utils import log
+from mx_infer.data_type import ProcessData, StopData, StopSign
+from mx_infer.framework.module_base import ModuleBase
+from mx_infer.utils import log
 
 
 class HandoutProcess(ModuleBase):

--- a/deploy/mx_infer/processors/detection/det_infer_process.py
+++ b/deploy/mx_infer/processors/detection/det_infer_process.py
@@ -1,8 +1,8 @@
 import numpy as np
 from mindx.sdk import base, Tensor
 
-from deploy.mx_infer.framework import ModuleBase
-from deploy.mx_infer.utils import get_matched_gear_hw, padding_with_np, \
+from mx_infer.framework import ModuleBase
+from mx_infer.utils import get_matched_gear_hw, padding_with_np, \
     get_shape_info
 
 

--- a/deploy/mx_infer/processors/detection/det_post_process.py
+++ b/deploy/mx_infer/processors/detection/det_post_process.py
@@ -1,8 +1,8 @@
 import cv2
 import numpy as np
 
-from deploy.mx_infer.framework import ModuleBase
-from deploy.mx_infer.utils import get_mini_boxes, unclip, construct_box, box_score_slow, \
+from mx_infer.framework import ModuleBase
+from mx_infer.utils import get_mini_boxes, unclip, construct_box, box_score_slow, \
     get_rotate_crop_image, get_hw_of_img, safe_div, box_score_fast
 
 

--- a/deploy/mx_infer/processors/detection/det_pre_process.py
+++ b/deploy/mx_infer/processors/detection/det_pre_process.py
@@ -1,7 +1,7 @@
 import numpy as np
 
-from deploy.mx_infer.framework import ModuleBase
-from deploy.mx_infer.utils import normalize, to_chw_image, \
+from mx_infer.framework import ModuleBase
+from mx_infer.utils import normalize, to_chw_image, \
     expand, get_hw_of_img, resize_by_limit_max_side, IMAGE_NET_IMAGE_STD, IMAGE_NET_IMAGE_MEAN, DBNET_LIMIT_SIDE, \
     NORMALIZE_SCALE
 

--- a/deploy/mx_infer/processors/recognition/rec_infer_process.py
+++ b/deploy/mx_infer/processors/recognition/rec_infer_process.py
@@ -4,8 +4,8 @@ from collections import defaultdict
 import numpy as np
 from mindx.sdk import base, Tensor
 
-from deploy.mx_infer.framework import ModuleBase
-from deploy.mx_infer.utils import get_shape_info, check_valid_file, check_valid_dir
+from mx_infer.framework import ModuleBase
+from mx_infer.utils import get_shape_info, check_valid_file, check_valid_dir
 
 
 class RecInferProcess(ModuleBase):

--- a/deploy/mx_infer/processors/recognition/rec_post_process.py
+++ b/deploy/mx_infer/processors/recognition/rec_post_process.py
@@ -2,8 +2,8 @@ import os.path
 
 import numpy as np
 
-from deploy.mx_infer.framework import ModuleBase, InferModelComb
-from deploy.mx_infer.utils import array_to_texts, file_base_check, log
+from mx_infer.framework import ModuleBase, InferModelComb
+from mx_infer.utils import array_to_texts, file_base_check, log
 
 
 class RecPostProcess(ModuleBase):

--- a/deploy/mx_infer/processors/recognition/rec_pre_process.py
+++ b/deploy/mx_infer/processors/recognition/rec_pre_process.py
@@ -5,9 +5,9 @@ import cv2
 import numpy as np
 from mindx.sdk import base
 
-from deploy.mx_infer.data_type.process_data import ProcessData
-from deploy.mx_infer.framework import ModuleBase, InferModelComb
-from deploy.mx_infer.utils import get_batch_list_greedy, get_hw_of_img, safe_div, get_matched_gear_hw, \
+from mx_infer.data_type.process_data import ProcessData
+from mx_infer.framework import ModuleBase, InferModelComb
+from mx_infer.utils import get_batch_list_greedy, get_hw_of_img, safe_div, get_matched_gear_hw, \
     padding_with_cv, normalize, to_chw_image, expand, padding_batch, bgr_to_gray, get_shape_info, \
     check_valid_file, check_valid_dir, NORMALIZE_SCALE, NORMALIZE_MEAN, NORMALIZE_STD
 

--- a/deploy/mx_infer/utils/safe_utils.py
+++ b/deploy/mx_infer/utils/safe_utils.py
@@ -1,8 +1,8 @@
+import json
 import os
 import re
-import stat
-import json
 import shutil
+import stat
 
 import cv2
 


### PR DESCRIPTION
Thank you for your contribution to the MindOCR repo.
Before submitting this PR, please make sure:

- [x] You have read the [Contributing Guidelines on pull requests](https://github.com/mindspore-lab/mindcv/blob/main/CONTRIBUTING.md)
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved terminology
- [x] You have added unit tests

## Motivation

fix some import path for inference

There are other folders under deploy path, but none of them are Python packages.
So mx_ Infer should be used as the root directory for inference packages.

## Test Plan

(How should this PR be tested? Do you require special setup to run the test or repro the fixed bug?)

## Related Issues and PRs

(Is this PR part of a group of changes? Link the other relevant PRs and Issues here. Use https://help.github.com/en/articles/closing-issues-using-keywords for help on GitHub syntax)
