### PR TITLE
fix `data_sink_mode` freeze, adjust DBNet augmentation pipeline

### DIFF
--- a/configs/det/dbnet/db_r50_icdar15.yaml
+++ b/configs/det/dbnet/db_r50_icdar15.yaml
@@ -1,6 +1,6 @@
 system:
   mode: 0 # 0 for graph mode, 1 for pynative mode in MindSpore
-  distribute: False 
+  distribute: False
   amp_level: 'O0'
   seed: 42
   val_while_train: True
@@ -16,7 +16,6 @@ model:
     name: DBFPN
     out_channels: 256
     bias: False
-    use_asf: False        # enable it for DB++
   head:
     name: DBHead
     k: 50
@@ -64,24 +63,26 @@ loss_scaler:
 
 train:
   ckpt_save_dir: './tmp_det'
-  dataset_sink_mode: False
+  dataset_sink_mode: True
   dataset:
     type: DetDataset
     dataset_root: /data/ocr_datasets
     data_dir: ic15/det/train/ch4_training_images
     label_file: ic15/det/train/det_gt.txt
     sample_ratio: 1.0
-    shuffle: True
     transform_pipeline:
       - DecodeImage:
           img_mode: RGB
           to_float32: False
       - DetLabelEncode:
-      - RandomScale:
-          scale_range: [ 1.022, 3.0 ]
+      - RandomColorAdjust:
+          brightness: 0.1255  # 32.0 / 255
+          saturation: 0.5
       - IaaAugment:
-          Affine: { rotate: [ -10, 10 ] }
           Fliplr: { p: 0.5 }
+          Affine: { rotate: [ -10, 10 ] }
+      - RandomScale:
+          scale_range: [ 0.5, 3.0 ]
       - RandomCropWithBBox:
           max_tries: 10
           min_crop_ratio: 0.1
@@ -93,9 +94,6 @@ train:
           shrink_ratio: 0.4
           thresh_min: 0.3
           thresh_max: 0.7
-      - RandomColorAdjust:
-          brightness: 0.1255  # 32.0 / 255
-          saturation: 0.5
       - NormalizeImage:
           bgr_to_rgb: False
           is_hwc: True
@@ -122,7 +120,6 @@ eval:
     data_dir: ic15/det/test/ch4_test_images
     label_file: ic15/det/test/det_gt.txt
     sample_ratio: 1.0
-    shuffle: False
     transform_pipeline:
       - DecodeImage:
           img_mode: RGB
@@ -149,4 +146,4 @@ eval:
     shuffle: False
     batch_size: 1 # TODO: due to dynamic shape of polygons (num of boxes varies), BS has to be 1
     drop_remainder: False
-    num_workers: 1
+    num_workers: 2

--- a/mindocr/data/transforms/general_transforms.py
+++ b/mindocr/data/transforms/general_transforms.py
@@ -2,7 +2,7 @@ from typing import List, Union
 import cv2
 import numpy as np
 from PIL import Image
-from mindspore.dataset.vision import RandomColorAdjust as MSRandomColorAdjust
+from mindspore.dataset.vision import RandomColorAdjust as MSRandomColorAdjust, ToPIL
 
 from ...data.constants import IMAGENET_DEFAULT_MEAN, IMAGENET_DEFAULT_STD
 
@@ -285,11 +285,13 @@ class RandomCropWithBBox:
 class RandomColorAdjust:
     def __init__(self, brightness=32.0 / 255, saturation=0.5):
         self._jitter = MSRandomColorAdjust(brightness=brightness, saturation=saturation)
+        self._pil = ToPIL()
 
     def __call__(self, data):
         """
         required keys: image
         modified keys: image
         """
-        data['image'] = self._jitter(data['image'])
+        # there's a bug in MindSpore that requires images to be converted to the PIL format first
+        data['image'] = np.array(self._jitter(self._pil(data['image'])))
         return data

--- a/mindocr/postprocess/det_postprocess.py
+++ b/mindocr/postprocess/det_postprocess.py
@@ -37,13 +37,13 @@ class DBPostprocess:
         # FIXME: dest_size is supposed to be the original image shape (pred.shape -> batch['shape'])
         dest_size = np.array(pred.shape[:0:-1])  # w, h order
         scale = dest_size / np.array(pred.shape[:0:-1])
-        
+
         # FIXME: output as dict, keep consistent return format to recognition
         return [self._extract_preds(pr, segm, scale, dest_size) for pr, segm in zip(pred, segmentation)]
 
     def _extract_preds(self, pred, bitmap, scale, dest_size):
         outs = cv2.findContours(bitmap.astype(np.uint8), cv2.RETR_LIST, cv2.CHAIN_APPROX_SIMPLE)
-        if len(outs) == 3:
+        if len(outs) == 3:  # FIXME: update to OpenCV 4.x and delete this
             _, contours, _ = outs[0], outs[1], outs[2]
         elif len(outs) == 2:
             contours, _ = outs[0], outs[1]


### PR DESCRIPTION
Thank you for your contribution to the MindOCR repo.
Before submitting this PR, please make sure:

- [x] You have read the [Contributing Guidelines on pull requests](https://github.com/mindspore-lab/mindcv/blob/main/CONTRIBUTING.md)
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved terminology
- [ ] You have added unit tests

## Motivation

Passing images to the `RandomColorAdjust` MindSpore's transform as `np.ndarray` causes training freeze when the `data_sink_mode` is set to `True`. This fix converts images to the `PIL` format first and converts them back to `np.ndarray` after color adjustment.