### PR TITLE
DBNet output changed  in inference mode for faster speed - only binary map is output

### DIFF
--- a/mindocr/postprocess/det_postprocess.py
+++ b/mindocr/postprocess/det_postprocess.py
@@ -30,8 +30,12 @@ class DBPostprocess:
                 polygons: np.ndarray of shape (N, K, 4, 2) for the polygons of objective regions if region_type is 'quad'
                 scores: np.ndarray of shape (N, K), score for each box
         """
-        pred = (pred[self._name] if isinstance(pred, dict) else pred[self._names[self._name]]).squeeze(1)
-        pred = pred.asnumpy()
+        if isinstance(pred, dict):
+            pred = pred[self._name]
+        elif isinstance(pred, tuple):
+            pred = pred[self._names[self._name]]
+        pred = pred.squeeze(1).asnumpy()
+        
         segmentation = pred >= self._binary_thresh
 
         # FIXME: dest_size is supposed to be the original image shape (pred.shape -> batch['shape'])


### PR DESCRIPTION
Thank you for your contribution to the MindOCR repo.
Before submitting this PR, please make sure:

- [x] You have read the [Contributing Guidelines on pull requests](https://github.com/mindspore-lab/mindcv/blob/main/CONTRIBUTING.md)
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved terminology
- [x] You have added unit tests

## Motivation

(Write your motivation for proposed changes here.)

## Test Plan

(How should this PR be tested? Do you require special setup to run the test or repro the fixed bug?)

## Related Issues and PRs

(Is this PR part of a group of changes? Link the other relevant PRs and Issues here. Use https://help.github.com/en/articles/closing-issues-using-keywords for help on GitHub syntax)
