### PR TITLE
Network head output type changed to fix CoreSegment error in graph mo…

### DIFF
--- a/mindocr/losses/rec_loss.py
+++ b/mindocr/losses/rec_loss.py
@@ -1,9 +1,10 @@
 import mindspore as ms
+from mindspore import Tensor
 from mindspore import nn
 from mindspore.nn.loss.loss import LossBase
 from mindspore import Tensor, Parameter
 from mindspore.common import dtype as mstype
-from mindspore import ops 
+from mindspore import ops
 import numpy as np
 
 __all__ = ['CTCLoss']
@@ -14,8 +15,8 @@ class CTCLoss(LossBase):
      CTCLoss definition
 
      Args:
-        pred_seq_len(int): the length of the predicted character sequence. For text images, this value equals to W - the width of feature map encoded by the visual bacbkone. This can be obtained by probing the output shape in the network. 
-            E.g., for a training image in shape (3, 32, 100), the feature map encoded by resnet34 bacbkone is in shape (512, 1, 4), W = 4, sequence len is 4. 
+        pred_seq_len(int): the length of the predicted character sequence. For text images, this value equals to W - the width of feature map encoded by the visual bacbkone. This can be obtained by probing the output shape in the network.
+            E.g., for a training image in shape (3, 32, 100), the feature map encoded by resnet34 bacbkone is in shape (512, 1, 4), W = 4, sequence len is 4.
         max_label_len(int): the maximum number of characters in a text label, i.e. max_text_len in yaml.
         batch_size(int): batch size of input logits. bs
      """
@@ -31,27 +32,27 @@ class CTCLoss(LossBase):
         self.label_indices = Tensor(np.array(label_indices), mstype.int64)
         #self.reshape = P.Reshape()
         self.ctc_loss = ops.CTCLoss(ctc_merge_repeated=True)
-        
+
         self.reduction = reduction
         print('D: ', self.label_indices.shape)
-    
+
     # TODO: diff from paddle, paddle takes `label_length` as input too.
-    def construct(self, pred, label):
+    def construct(self, pred: Tensor, label: Tensor):
         '''
         Args:
-            pred (dict): {head_out: logits}
-                        logits is a Tensor in shape (W, BS, NC), where W - seq len, BS - batch size. NC - num of classes (types of character + blank + 1)
+            pred (Tensor): network prediction which is a
+                logit Tensor in shape (W, BS, NC), where W - seq len, BS - batch size. NC - num of classes (types of character + blank + 1)
             label (Tensor): GT sequence of character indices in shape (BS, SL), SL - sequence length, which is padded to max_text_length
         Returns:
-            loss value
+            loss value (Tensor)
         '''
-        logit = pred['head_out']
-        #T, bs, nc = logit.shape 
+        logit = pred
+        #T, bs, nc = logit.shape
         #logit = ops.reshape(logit, (T*bs, nc))
         label_values = ops.reshape(label, (-1,))
 
         loss, _ = self.ctc_loss(logit, self.label_indices, label_values, self.sequence_length)
-        
+
         if self.reduction=='mean':
             loss = loss.mean()
 
@@ -65,9 +66,9 @@ if __name__ == '__main__':
     pred_seq_len  = 24
 
     loss_fn = CTCLoss(pred_seq_len, max_text_length, bs)
-    
+
     x = ms.Tensor(np.random.rand(pred_seq_len, bs, nc), dtype=ms.float32)
     label = ms.Tensor(np.random.randint(0, nc,  size=(bs, max_text_length)), dtype=ms.int32)
 
-    loss = loss_fn({'head_out': x}, label)
+    loss = loss_fn(x, label)
     print(loss)

--- a/mindocr/metrics/det_metrics.py
+++ b/mindocr/metrics/det_metrics.py
@@ -21,6 +21,8 @@ def _get_iou(pd, pg):
 
 
 class DetectionIoUEvaluator:
+    '''
+    '''
     def __init__(self, min_iou=0.5, min_intersect=0.5):
         self._min_iou = min_iou
         self._min_intersect = min_intersect
@@ -77,6 +79,8 @@ class DetectionIoUEvaluator:
 
 
 class DetMetric(nn.Metric):
+    '''
+    '''
     def __init__(self, device_num=1, **kwargs):
         super().__init__()
         self._evaluator = DetectionIoUEvaluator()

--- a/mindocr/metrics/rec_metrics.py
+++ b/mindocr/metrics/rec_metrics.py
@@ -79,7 +79,6 @@ class RecMetric(nn.Metric):
         if len(inputs) != 2:
             raise ValueError('Length of inputs should be 2')
         preds, gt = inputs
-
         pred_texts = preds['texts']
         #pred_confs = preds['confs']
         #print('pred: ', pred_texts, len(pred_texts))

--- a/mindocr/models/README.md
+++ b/mindocr/models/README.md
@@ -49,7 +49,7 @@ python tests/ut/test_model.py --config /path/to/yaml_config_file
 * Class naming: **{HeadName}** e.g. `class DBHead`
 * Class `__init__` args: MUST contain `in_channels` param as the first position, e.g. `__init__(self, in_channels, out_channels=2, **kwargs)`.  
 * Class `construct` args: feature (Tensor)
-* Class `construct` return: prediction Union[Tensor, dict]. If it is a dict, key names should match the used key in loss function. {'maps': out, 'score': score},  which should match the loss function.
+* Class `construct` return: prediction (Union(Tensor, Tuple[Tensor])). If there is only one output, return Tensor. If there are multiple outputs, return Tuple of Tensor, e.g., `return output1, output2, output_N`. Note that the order should match the loss function or the postprocess function.
 
 
 **Note:** if there is no neck in the model architecture like crnn, you can skip writing for neck. `BaseModel` will select the last feature of the features (List(Tensor)) output by Backbone, and forward it Head module.

--- a/mindocr/models/base_model.py
+++ b/mindocr/models/base_model.py
@@ -10,11 +10,11 @@ class BaseModel(nn.Cell):
     def __init__(self, config: dict):
         """
         Args:
-            config (dict): model config 
+            config (dict): model config
         """
         super(BaseModel, self).__init__()
 
-        config = Dict(config)  
+        config = Dict(config)
         backbone_name = config.backbone.pop('name')
         self.backbone = build_backbone(backbone_name, **config.backbone)
 
@@ -31,7 +31,7 @@ class BaseModel(nn.Cell):
         head_name = config.head.pop('name')
         self.head = build_head(head_name, in_channels=self.neck.out_channels, **config.head)
 
-        self.model_name = f'{backbone_name}_{neck_name}_{head_name}'  
+        self.model_name = f'{backbone_name}_{neck_name}_{head_name}'
 
     def construct(self, x):
         # TODO: return bout, hout for debugging, using a dict.
@@ -41,22 +41,9 @@ class BaseModel(nn.Cell):
 
         hout = self.head(nout)
 
-        # resize back for postprocess 
+        # resize back for postprocess
         #y = F.interpolate(y, size=(H, W), mode='bilinear', align_corners=True)
 
-        # for multi head, save ctc neck out for udml
-        '''
-        if isinstance(x, dict) and 'ctc_neck' in x.keys():
-            y["neck_out"] = x["ctc_neck"]
-            y["head_out"] = x
-        elif isinstance(x, dict):
-            y.update(x)
-        else:
-            y["head_out"] = x
-        
-        
-        '''
-        
         return hout
 
 
@@ -64,7 +51,7 @@ if __name__=='__main__':
     model_config = {
             "backbone": {
                 'name': 'det_resnet50',
-                'pretrained': False 
+                'pretrained': False
                 },
             "neck": {
                 "name": 'FPN',
@@ -75,10 +62,10 @@ if __name__=='__main__':
                 "out_channels": 2,
                 "k": 50
                 }
-            
+
             }
     model_config.pop('neck')
-    model = BaseModel(model_config) 
+    model = BaseModel(model_config)
 
     import mindspore as ms
     import time

--- a/mindocr/models/heads/conv_head.py
+++ b/mindocr/models/heads/conv_head.py
@@ -9,5 +9,5 @@ class ConvHead(nn.Cell):
         )
 
     def construct(self, x):
-        return {'map': self.conv(x)}
+        return  self.conv(x)
 

--- a/mindocr/models/heads/rec_ctc_head.py
+++ b/mindocr/models/heads/rec_ctc_head.py
@@ -61,13 +61,13 @@ class CTCHead(nn.Cell):
             self.dense2 = nn.Dense(mid_channels, out_channels, weight_init=weight_init, bias_init=bias_init)
             #self.dropout = nn.Dropout(keep_prob)
 
-    def construct(self, x):
+    def construct(self, x: ms.Tensor) -> ms.Tensor:
         """Feed Forward construct.
         Args:
             x (Tensor): feature in shape [W, BS, 2*C]
         Returns:
             h (Tensor): if training, h is logits in shape [W, BS, num_classes], where W - sequence len, fixed. (dim order required by ms.ctcloss)
-                        if not training, h is probabilites in shape [BS, W, num_classes].
+                        if not training, h is class probabilites in shape [BS, W, num_classes].
         """
         h = self.dense1(x)
         #x = self.dropout(x)
@@ -80,8 +80,7 @@ class CTCHead(nn.Cell):
             h = ops.Softmax(axis=2)(h)
             h = h.transpose((1, 0, 2))
 
-        pred = {'head_out': h}
-        return pred
+        return h
 
 
 if __name__ == '__main__':

--- a/mindocr/postprocess/det_postprocess.py
+++ b/mindocr/postprocess/det_postprocess.py
@@ -1,6 +1,9 @@
+from typing import Tuple, Union
 import cv2
 import numpy as np
 from shapely.geometry import Polygon
+import mindspore as ms
+from mindspore import Tensor
 
 from ..data.transforms.det_transforms import expand_poly
 
@@ -21,27 +24,28 @@ class DBPostprocess:
 
     def __call__(self, pred):
         """
-        pred:
-            binary: text region segmentation map, with shape (N, H, W)
-            thresh: [if exists] threshold prediction with shape (N, H, W)
-            thresh_binary: [if exists] binarized with threshold, (N, H, W)
+        pred (Union[Tensor, Tuple[Tensor], np.ndarray]):
+            binary: text region segmentation map, with shape (N, 1, H, W)
+            thresh: [if exists] threshold prediction with shape (N, 1, H, W) (optional)
+            thresh_binary: [if exists] binarized with threshold, (N, 1, H, W) (optional)
         Returns:
             result (dict) with keys:
                 polygons: np.ndarray of shape (N, K, 4, 2) for the polygons of objective regions if region_type is 'quad'
                 scores: np.ndarray of shape (N, K), score for each box
         """
-        if isinstance(pred, dict):
-            pred = pred[self._name]
-        elif isinstance(pred, tuple):
+        if isinstance(pred, tuple):
             pred = pred[self._names[self._name]]
-        pred = pred.squeeze(1).asnumpy()
-        
+        if isinstance(pred, Tensor):
+            pred = pred.asnumpy()
+        pred = pred.squeeze(1)
+
         segmentation = pred >= self._binary_thresh
 
         # FIXME: dest_size is supposed to be the original image shape (pred.shape -> batch['shape'])
         dest_size = np.array(pred.shape[:0:-1])  # w, h order
         scale = dest_size / np.array(pred.shape[:0:-1])
 
+        # TODO:
         # FIXME: output as dict, keep consistent return format to recognition
         return [self._extract_preds(pr, segm, scale, dest_size) for pr, segm in zip(pred, segmentation)]
 

--- a/mindocr/postprocess/rec_postprocess.py
+++ b/mindocr/postprocess/rec_postprocess.py
@@ -5,6 +5,7 @@ import cv2
 import math
 import numpy as np
 import mindspore as ms
+from mindspore import Tensor
 
 __all__ = ['RecCTCLabelDecode']
 
@@ -111,21 +112,19 @@ class RecCTCLabelDecode(object):
         return texts, confs
 
 
-    def __call__(self, preds: Union[dict, List], labels = None, **kwargs):
+    def __call__(self, preds: Union[Tensor, np.ndarray], labels = None, **kwargs):
         '''
         Args:
-            preds (dict or tuple): containing prediction tensor in shape [W, BS, num_classes]
-            labels ():
+            preds (Union[Tensor, np.ndarray]): network prediction, class probabilities in shape [BS, W, num_classes], where W is the sequence length.
+            labels: optional
         Return:
             texts (List[Tuple]): list of string
 
         '''
         if isinstance(preds, tuple):
             preds = preds[-1]
-        elif isinstance(preds, dict):
-            preds = preds['head_out'] # TODO: change name
 
-        if isinstance(preds, ms.Tensor):
+        if isinstance(preds, Tensor):
             preds = preds.asnumpy()
 
         #preds = preds.transpose([1, 0, 2]) # [W, BS, C] -> [BS, W, C]. already did in model head.

--- a/mindocr/utils/callbacks.py
+++ b/mindocr/utils/callbacks.py
@@ -56,17 +56,15 @@ class Evaluator:
         for i, data in tqdm(enumerate(iterator), total=dataloader.get_dataset_size()):
             # start = time.time()
             # TODO: if network input is not just an image.
-            # assume the first element is image
             img = data[0]  # ms.Tensor(batch[0])
             gt = data[1:]  # ground truth,  (polys, ignore_tags) for det,
 
-            # TODO: in graph mode, the output dict is somehow converted to tuple. Is the order of in tuple the same as dict binary, thresh, thres_binary? to check
-            # {'binary':, 'thresh: ','thresh_binary': } for text detect; {'head_out': } for text rec
-            net_preds = self.net(img)
             # net_inputs = data[:num_columns_to_net]
             # gt = data[num_columns_to_net:] # ground truth
-            # preds = self.net(*net_inputs) # head output is dict. for text det {'binary', ...},  for text rec, {'head_out': }
+            # preds = self.net(*net_inputs)
             # print('net predictions', preds)
+
+            net_preds = self.net(img)
 
             if self.postprocessor is not None:
                 preds = self.postprocessor(net_preds)  # {'polygons':, 'scores':} for text det
@@ -74,17 +72,6 @@ class Evaluator:
             # metric internal update
             for m in self.metrics:
                 m.update(preds, gt)
-
-            if self.verbose:
-                if isinstance(net_preds, tuple):
-                    print('pred binary map:', net_preds[0].shape, net_preds[0].max(), net_preds[0].min())
-                    print('thresh binary map:', net_preds[2].shape, net_preds[2].max(), net_preds[2].min())
-                else:
-                    print('pred binary map:', net_preds['binary'].shape, net_preds['binary'].max(),
-                          net_preds['binary'].min())
-                    print('thresh binary map:', net_preds['thresh_binary'].shape, net_preds['thresh_binary'].max(),
-                          net_preds['binary'].min())
-                print('pred polys:', preds['polygons'])
 
             if self.visualize:
                 img = img[0].asnumpy()

--- a/mindocr/utils/model_wrapper.py
+++ b/mindocr/utils/model_wrapper.py
@@ -1,26 +1,28 @@
 from mindspore import nn
 import mindspore.ops as ops
 from mindspore.communication import get_group_size
+
+
 class NetWithLossWrapper(nn.Cell):
     '''
     A universal wrapper for any network with any loss.
-    
+
     Assume dataloader output follows the order (input1, input2, ..., label1, label2, label3, ... )  for network and loss.
-    
+
     Args:
         net (nn.Cell): network
-        loss_fn: loss function 
+        loss_fn: loss function
         num_net_inputs: number of network input, e.g. 1
         num_labels: number of labels used for loss fn computation. If None, all the remaining args will be fed into loss func.
     '''
     def __init__(self, net, loss_fn, num_net_inputs=1, num_labels=None):
         super().__init__(auto_prefix=False)
-        self._net = net 
+        self._net = net
         self._loss_fn = loss_fn
         # TODO: get this automatically from net and loss func
         self.num_net_inputs = num_net_inputs
         self.num_labels = num_labels
-        #self.net_forward_input = ['img'] 
+        #self.net_forward_input = ['img']
         #self.loss_forward_input = ['gt', 'gt_mask', 'thresh_map', 'thresh_mask']
 
     def construct(self, *args):
@@ -31,7 +33,7 @@ class NetWithLossWrapper(nn.Cell):
             loss_val (Tensor): loss value
         '''
         pred = self._net(*args[:self.num_net_inputs])
-        if self.num_labels is None: 
+        if self.num_labels is None:
             loss_val = self._loss_fn(pred, *args[self.num_net_inputs:])
         else:
             loss_val = self._loss_fn(pred, *args[self.num_net_inputs:self.num_net_inputs+self.num_labels])
@@ -40,25 +42,25 @@ class NetWithLossWrapper(nn.Cell):
 
 class NetWithEvalWrapper(nn.Cell):
     '''
-    A universal wrapper for any network with any loss for evaluation pipeline. 
-    Difference from NetWithLossWrapper: it returns loss_val, pred, and labels.  
-    
+    A universal wrapper for any network with any loss for evaluation pipeline.
+    Difference from NetWithLossWrapper: it returns loss_val, pred, and labels.
+
     Assume dataloader output follows the order (input1, input2, ..., label1, label2, label3, ... )  for network and loss.
-    
+
     Args:
         net (nn.Cell): network
-        loss_fn: loss function, if None, will not compute loss for evaluation dataset 
+        loss_fn: loss function, if None, will not compute loss for evaluation dataset
         num_net_inputs: number of network input, e.g. 1
         num_labels: number of labels used for loss fn computation. If None, all the remaining args will be fed into loss func.
     '''
     def __init__(self, net, loss_fn=None, num_net_inputs=1, num_labels=None):
         super().__init__(auto_prefix=False)
-        self._net = net 
+        self._net = net
         self._loss_fn = loss_fn
         # TODO: get this automatically from net and loss func
         self.num_net_inputs = num_net_inputs
         self.num_labels = num_labels
-        #self.net_forward_input = ['img'] 
+        #self.net_forward_input = ['img']
         #self.loss_forward_input = ['gt', 'gt_mask', 'thresh_map', 'thresh_mask']
 
     def construct(self, *args):
@@ -66,21 +68,21 @@ class NetWithEvalWrapper(nn.Cell):
         Args:
             args (Tuple): contains network inputs, labels (given by data loader)
         Returns:
-            Tuple: loss value (Tensor), pred (dict), labels (Tuple) 
+            Tuple: loss value (Tensor), pred (Union[Tensor, Tuple[Tensor]]), labels (Tuple)
         '''
         # TODO: pred is a dict
         pred = self._net(*args[:self.num_net_inputs])
-        if self.num_labels is None: 
+        if self.num_labels is None:
             labels = args[self.num_net_inputs:]
         else:
             labels = args[self.num_net_inputs:self.num_net_inputs+self.num_labels]
-        
+
         if self._loss_fn is not None:
             loss_val = self._loss_fn(pred, *labels)
         else:
             loss_val = None
-        
-        return loss_val, pred, labels 
+
+        return loss_val, pred, labels
 
 
 class DBNetWithLossCell(nn.Cell):
@@ -95,9 +97,9 @@ class DBNetWithLossCell(nn.Cell):
     def __init__(self, net, loss_fn):
         super().__init__(auto_prefix=False)
 
-        self._net = net 
+        self._net = net
         self._loss_fn = loss_fn
-    
+
     # Note: this order should be consistent with the dataloader output
     def construct(self, img, gt, gt_mask, thresh_map, thresh_mask):
         pred = self._net(img)

--- a/tests/st/test_train_eval_dummy.py
+++ b/tests/st/test_train_eval_dummy.py
@@ -96,9 +96,7 @@ def test_train_eval(task, val_while_train, gradient_accumulation_steps, clip_gra
 
 
 if __name__ == '__main__':
-    #test_train_eval('det', True)
-    #test_train_eval('rec', True, 1, False)
-    #test_train_eval('det', True, 1, False, None)
-    #test_train_eval('det', True, 2, False, None)
     #test_train_eval('rec', True, 1, True, 'filter_norm_and_bias')
-    test_train_eval('rec', True, 2, False, None)
+    test_train_eval('det', True, 1, False, None)
+    #test_train_eval('rec', True, 1, True, 'filter_norm_and_bias')
+    #test_train_eval('rec', True, 2, False, None)

--- a/tests/ut/test_datasets.py
+++ b/tests/ut/test_datasets.py
@@ -14,8 +14,8 @@ from mindocr.utils.visualize import show_img, draw_bboxes, recover_image
 
 
 @pytest.mark.parametrize('task', ['det', 'rec'])
-#@pytest.mark.parametrize('phase', ['train', 'eval'])
-def test_build_dataset(task, phase='train', verbose=False, visualize=False):
+@pytest.mark.parametrize('phase', ['train', 'eval'])
+def test_build_dataset(task, phase, verbose=False, visualize=False):
     # modify ocr predefined yaml for minimum test
     if task == 'det':
         config_fp = 'configs/det/dbnet/db_r50_icdar15.yaml'
@@ -68,4 +68,5 @@ def test_build_dataset(task, phase='train', verbose=False, visualize=False):
 
 
 if __name__ == '__main__':
-    test_build_dataset(task='rec', phase='train', visualize=False)
+    #test_build_dataset(task='rec', phase='train', visualize=False)
+    test_build_dataset(task='det', phase='train', visualize=False)

--- a/tests/ut/test_models.py
+++ b/tests/ut/test_models.py
@@ -44,8 +44,11 @@ def _infer_dummy(model, task='det', verbose=True):
         print('neck output shape: ', nout.shape)
         hout = model.head(nout)
         print('head output shape: ')
-        for k in hout:
-            print('\r', k, hout[k].shape)
+        if isinstance(hout, tuple):
+            for ho in hout:
+                print(ho.shape)
+        else:
+            print(hout.shape)
 
         return hout
 


### PR DESCRIPTION
…de in MS 2.0rc caused by dict output type

Thank you for your contribution to the MindOCR repo.
Before submitting this PR, please make sure:

- [x] You have read the [Contributing Guidelines on pull requests](https://github.com/mindspore-lab/mindcv/blob/main/CONTRIBUTING.md)
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved terminology
- [x] You have added unit tests

## Motivation

在Ascend + MS 2.0rc + Graph Mode 配置下，评估脚本出现 Core Segment报错。
经排查定位，原因是网络输出使用了 Dictionary 类型，改为Tensor 或 Tuple类型后，评估正常。**可能是MS2.0rc的BUG，因为MS1.9, MS1.10均无此报错。**
因此，network head输出统一由字典类型 改成 Tensor  或 Tuple(如多输出) 格式。

## Test Plan

(How should this PR be tested? Do you require special setup to run the test or repro the fixed bug?)

## Related Issues and PRs

(Is this PR part of a group of changes? Link the other relevant PRs and Issues here. Use https://help.github.com/en/articles/closing-issues-using-keywords for help on GitHub syntax)
