### PR TITLE
Datasets Conversion Support and Fixing Bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,29 @@ For the detailed performance of the trained models, please refer to [configs](./
 
 For detailed inference performance using MX engine, please refer to [mx inference performance](docs/cn/inference_models_cn.md) 
 
+## Datasets
+
+### Download 
+
+We give instructions on how to download the following datasets.
+
+<details open>
+<summary>Text Detection</summary>
+
+- [x] ICDAR2015 [paper](https://rrc.cvc.uab.es/files/short_rrc_2015.pdf) [homepage](https://rrc.cvc.uab.es/?ch=4) [download instruction](docs/en/datasets/icdar2015.md)
+
+- [x] Total-Text [paper](https://arxiv.org/abs/1710.10400) [homepage](https://github.com/cs-chan/Total-Text-Dataset/tree/master/Dataset) [download instruction](docs/en/datasets/totaltext.md)
+
+- [x] Syntext150k [paper](https://arxiv.org/abs/2002.10200) [homepage](https://github.com/aim-uofa/AdelaiDet) [download instruction](docs/en/datasets/syntext150k.md)
+
+- [x] MLT2017 [paper](https://ieeexplore.ieee.org/abstract/document/8270168) [homepage](https://rrc.cvc.uab.es/?ch=8&com=introduction) [download instruction](docs/en/datasets/mlt2017.md)
+
+</details>
+
+### Conversion
+
+After downloading these datasets in the `DATASETS_DIR` folder, you can run `bash tools/convert_datasets.sh` to convert all downloaded datasets into the target format. [Here](tools/dataset_converters/README.md) is an example of icdar2015 dataset converting.
+
 ## Notes
 
 ### Change Log

--- a/README_CN.md
+++ b/README_CN.md
@@ -123,6 +123,29 @@ MindOCR集成了MX推理引擎，支持文本检测识别任务，请参考[mx_i
 
 基于MX引擎的推理性能结果及支持模型列表，请见[mx inference performance](docs/cn/inference_models_cn.md) 
 
+## 数据集
+### 下载
+
+我们提供以下数据集的下载说明。
+
+<details open>
+<summary>文本检测</summary>
+
+- [x] ICDAR2015 [论文]((https://rrc.cvc.uab.es/files/short_rrc_2015.pdf)) [主页]((https://rrc.cvc.uab.es/?ch=4)) [下载说明](docs/cn/datasets/icdar2015_CN.md)
+
+- [x] Total-Text [论文](https://arxiv.org/abs/1710.10400) [主页](https://github.com/cs-chan/Total-Text-Dataset/tree/master/Dataset) [下载说明](docs/cn/datasets/totaltext_CN.md)
+
+- [x] Syntext150k [论文](https://arxiv.org/abs/2002.10200) [主页](https://github.com/aim-uofa/AdelaiDet) [下载说明](docs/cn/datasets/syntext150k_CN.md)
+
+- [x] MLT2017 [论文](https://ieeexplore.ieee.org/abstract/document/8270168) [主页](https://rrc.cvc.uab.es/?ch=8&com=introduction) [下载说明](docs/cn/datasets/mlt2017_CN.md)
+
+</details>
+
+### 转换
+
+在 `DATASETS_DIR` 文件夹中下载这些数据集后，您可以运行 `bash tools/convert_datasets.sh` 将所有下载的数据集转换为目标格式。[这里](tools/dataset_converters/README_CN.md)有一个 icdar2015 数据集转换的例子。
+
+
 ## 重要信息
 
 ### 变更日志

--- a/docs/cn/datasets/icdar2015_CN.md
+++ b/docs/cn/datasets/icdar2015_CN.md
@@ -8,50 +8,45 @@ ICDAR 2015 [文章](https://rrc.cvc.uab.es/?ch=4)
 <details>
   <summary>从何处下载 ICDAR 2015</summary>
 
+ICDAR 2015 挑战赛分为三个任务。任务1是文本定位。任务3是单词识别。任务4是端到端文本检测识别。任务2文本分割的数据不可用。
+
+### Text Localization
+
+有四个与任务1相关的文件需要下载（[下载地址](https://rrc.cvc.uab.es/?ch=4&com=downloads)）， 它们分别是：
+
+```
+ch4_training_images.zip
+ch4_training_localization_transcription_gt.zip
+ch4_test_images.zip
+Challenge4_Test_Task1_GT.zip
+```
+
 ### Word Recognition
 
-Training Set
+有三个与任务3相关的文件需要下载（[下载地址](https://rrc.cvc.uab.es/?ch=4&com=downloads)）， 它们分别是：
 
-- [Training Set Word Images, along with Transcriptions Ground truth (40.5MB)](https://rrc.cvc.uab.es/?com=downloads&action=download&ch=4&f=aHR0cHM6Ly9ycmMuY3ZjLnVhYi5lcy8/Y29tPWRvd25sb2FkcyZhY3Rpb249ZG93bmxvYWQmZmlsZT1jaDRfdHJhaW5pbmdfd29yZF9pbWFnZXNfZ3Quemlw).- ~4468 cut out word images corresponding to the axis oriented bounding boxes of the words are provided along with a single text file with the relative coordinates of the bounding shape within each word image. Transcription ground truth is provided in a single txt file.
+```
+ch4_training_word_images_gt.zip
+ch4_test_word_images_gt.zip
+Challenge4_Test_Task3_GT.txt
+```
 
-Test Set
-
-- [Test Set Word Images (21.5MB)](https://rrc.cvc.uab.es/?com=downloads&action=download&ch=4&f=aHR0cHM6Ly9ycmMuY3ZjLnVhYi5lcy8/Y29tPWRvd25sb2FkcyZhY3Rpb249ZG93bmxvYWQmZmlsZT1jaDRfdGVzdF93b3JkX2ltYWdlc19ndC56aXA=).- 2077 cut out word images corresponding to the axis oriented bounding boxes of the words are provided along with a single text file with the relative coordinates of the bounding shape within each word image. You can submit your results for this Task over the images of the test set through the My Methods section.
-
-- [Test Set Ground Truth (49Kb)](https://rrc.cvc.uab.es/?com=downloads&action=download&ch=4&f=aHR0cHM6Ly9ycmMuY3ZjLnVhYi5lcy9kb3dubG9hZHMvQ2hhbGxlbmdlNF9UZXN0X1Rhc2szX0dULnR4dA==). - A single text file with the transcriptions of the 2077 images of the test set. Each line corresponds to an image of the test set.
+这三个文件仅用于训练单词识别模型。训练文本检测模型不需要这三个文件。
 
 ### E2E
-Training Set
 
+有九个与任务4相关的文件需要下载（[下载地址](https://rrc.cvc.uab.es/?ch=4&com=downloads)）。其中包括任务1中的四个文件， 还有五个词汇文件。
 
-[source](https://rrc.cvc.uab.es/?ch=4&com=downloads)
+```
+ch4_training_vocabulary.txt
+ch4_training_vocabularies_per_image.zip
+ch4_test_vocabulary.txt
+ch4_test_vocabularies_per_image.zip
+GenericVocabulary.txt
+```
 
-- [Training Set Images (88.5MB)](https://rrc.cvc.uab.es/?com=downloads&action=download&ch=4&f=aHR0cHM6Ly9ycmMuY3ZjLnVhYi5lcy8/Y29tPWRvd25sb2FkcyZhY3Rpb249ZG93bmxvYWQmZmlsZT1jaDRfdHJhaW5pbmdfaW1hZ2VzLnppcA==).- 1000 images obtained with wearable cameras
+如果您下载了一个名为 `Challenge4_Test_Task4_GT.zip` 的文件，请注意它与 `Challenge4_Test_Task1_GT.zip` 是相同的文件，除了名称不同。在这个repo中，我们将使用 `Challenge4_Test_Task4_GT.zip` 来代替 ICDAR2015 数据集的文件 `Challenge4_Test_Task1_GT.zip`。
 
-- [Training Set Vocabulary (16KB)](https://rrc.cvc.uab.es/?com=downloads&action=download&ch=4&f=aHR0cHM6Ly9ycmMuY3ZjLnVhYi5lcy8/Y29tPWRvd25sb2FkcyZhY3Rpb249ZG93bmxvYWQmZmlsZT1jaDRfdHJhaW5pbmdfdm9jYWJ1bGFyeS50eHQ=).- Vocabulary of all words (words of 3 characters or longer comprising only letters) appearing in the training set
-
-- [Training Set Per-image Vocabularies (504KB)](https://rrc.cvc.uab.es/?com=downloads&action=download&ch=4&f=aHR0cHM6Ly9ycmMuY3ZjLnVhYi5lcy8/Y29tPWRvd25sb2FkcyZhY3Rpb249ZG93bmxvYWQmZmlsZT1jaDRfdHJhaW5pbmdfdm9jYWJ1bGFyaWVzX3Blcl9pbWFnZS56aXA=).- Vocabularies of 100 words per image, comprising the words appearing in the image plus distractors
-
-- [Training Set Localisation and Transcription Ground Truth (157KB)](https://rrc.cvc.uab.es/?com=downloads&action=download&ch=4&f=aHR0cHM6Ly9ycmMuY3ZjLnVhYi5lcy8/Y29tPWRvd25sb2FkcyZhY3Rpb249ZG93bmxvYWQmZmlsZT1jaDRfdHJhaW5pbmdfbG9jYWxpemF0aW9uX3RyYW5zY3JpcHRpb25fZ3Quemlw).- 1000 text files with word level localisation and transcription ground truth
-
-Test Set
-
-- [Test Set Images (43.3MB)](https://rrc.cvc.uab.es/?com=downloads&action=download&ch=4&f=aHR0cHM6Ly9ycmMuY3ZjLnVhYi5lcy8/Y29tPWRvd25sb2FkcyZhY3Rpb249ZG93bmxvYWQmZmlsZT1jaDRfdGVzdF9pbWFnZXMuemlw).- 500 images obtained with wearable cameras. You can submit your results for this Task over the images of the test set through the My Methods section.
-
-- [Test Set Vocabulary (8KB)](https://rrc.cvc.uab.es/?com=downloads&action=download&ch=4&f=aHR0cHM6Ly9ycmMuY3ZjLnVhYi5lcy8/Y29tPWRvd25sb2FkcyZhY3Rpb249ZG93bmxvYWQmZmlsZT1jaDRfdGVzdF92b2NhYnVsYXJ5LnR4dA==).- Vocabulary of all words (words of 3 characters or longer comprising only letters) appearing in the test set
-
-- [Test Set Per-image Vocabularies (248KB)](https://rrc.cvc.uab.es/?com=downloads&action=download&ch=4&f=aHR0cHM6Ly9ycmMuY3ZjLnVhYi5lcy8/Y29tPWRvd25sb2FkcyZhY3Rpb249ZG93bmxvYWQmZmlsZT1jaDRfdGVzdF92b2NhYnVsYXJpZXNfcGVyX2ltYWdlLnppcA==).- Vocabularies of 100 words per image, comprising the words appearing in the image plus distractors
-
-- [Test Set Ground Truth (244Kb)](https://rrc.cvc.uab.es/?com=downloads&action=download&ch=4&f=aHR0cHM6Ly9ycmMuY3ZjLnVhYi5lcy9kb3dubG9hZHMvQ2hhbGxlbmdlNF9UZXN0X1Rhc2s0X0dULnppcA==). - 500 text files with text localisation bounding boxes for the images of the test set.
-
-Other
-
-- [Generic Vocabulary (796KB)](https://rrc.cvc.uab.es/?com=downloads&action=download&ch=4&f=aHR0cHM6Ly9ycmMuY3ZjLnVhYi5lcy8/Y29tPWRvd25sb2FkcyZhY3Rpb249ZG93bmxvYWQmZmlsZT1HZW5lcmljVm9jYWJ1bGFyeS50eHQ=).- A vocabulary of about 90k words derived from the dataset publicly available here. Please consult [1,2] for further information as well as the disclaimer in the vocabulary file itself.
-
-
-References
-1. M. Jaderberg, K. Simonyan, A. Vedaldi, and A. Zisserman, "Synthetic data and artificial neural networks for natural scene text recognition", arXiv preprint arXiv:1406.2227, 2014
-2. M. Jaderberg, K. Simonyan, A. Vedaldi, and A. Zisserman, "Reading Text in the Wild with Convolutional Neural Networks", arXiv preprint arXiv:1412.1842, 2014
 
 </details>
 

--- a/docs/cn/datasets/mlt2017_CN.md
+++ b/docs/cn/datasets/mlt2017_CN.md
@@ -4,12 +4,63 @@
 
 MLT (Multi-Lingual) 2017 [文章](https://ieeexplore.ieee.org/abstract/document/8270168)
 
-[下载地址](https://rrc.cvc.uab.es/?ch=8)
+[下载地址](https://rrc.cvc.uab.es/?ch=8&com=downloads): 在下载之前，您需要先注册一个账号。
+
+<details>
+  <summary>从何处下载 MLT 2017</summary>
+
+MLT 2017 数据集包含两个任务. 任务 1 是文本检测 (多语言文本)。 任务2是文本识别。
+
+### 文本检测
+
+有11个与任务1相关的文件需要下载（[下载地址](https://rrc.cvc.uab.es/?ch=8&com=downloads)）， 它们分别是：
+
+```
+ch8_training_images_x.zip(x from 1 to 8)
+ch8_validation_images.zip
+ch8_training_localization_transcription_gt_v2.zip
+ch8_validation_localization_transcription_gt_v2.zip
+```
+
+测试集不需要下载。
+
+### 文本识别
+
+有6个与任务2相关的文件需要下载（[下载地址](https://rrc.cvc.uab.es/?ch=8&com=downloads)）， 它们分别是：
+```
+ ch8_training_word_images_gt_part_x.zip (x from 1 to 3)
+ ch8_validation_word_images_gt.zip
+ ch8_training_word_gt_v2.zip
+ ch8_validation_word_gt_v2.zip
+ ```
+</details>
+
 
 在下载完成后, 将文件放于 `[path-to-data-dir]` 文件夹内，如下所示:
 ```
 path-to-data-dir/
-  mlt2017/  
+  mlt2017/
+    # text detection
+    ch8_training_images_1.zip
+    ch8_training_images_2.zip
+    ch8_training_images_3.zip
+    ch8_training_images_4.zip
+    ch8_training_images_5.zip
+    ch8_training_images_6.zip
+    ch8_training_images_7.zip
+    ch8_training_images_8.zip
+    ch8_training_localization_transcription_gt_v2.zip
+    ch8_validation_images.zip
+    ch8_validation_localization_transcription_gt_v2.zip
+    # word recognition
+    ch8_training_word_images_gt_part_1.zip
+    ch8_training_word_images_gt_part_2.zip
+    ch8_training_word_images_gt_part_3.zip
+    ch8_training_word_gt_v2.zip
+    ch8_validation_word_images_gt.zip
+    ch8_validation_word_gt_v2.zip
+    
+    
 ```
 
 [返回](../../../tools/dataset_converters/README_CN.md)

--- a/docs/en/datasets/icdar2015.md
+++ b/docs/en/datasets/icdar2015.md
@@ -8,50 +8,43 @@ ICDAR 2015 [paper](https://rrc.cvc.uab.es/?ch=4)
 <details>
   <summary>Where to Download ICDAR 2015</summary>
 
+ICDAR 2015 Challenge has three tasks. Task 1 is Text Localization. Task 3 is Word Recognition. Task 4 is End-to-end Text Spotting. Task 2 Text Segmentation is not available.
+
+### Text Localization
+
+The four files downloaded from [web](https://rrc.cvc.uab.es/?ch=4&com=downloads) for task 1 are 
+```
+ch4_training_images.zip
+ch4_training_localization_transcription_gt.zip
+ch4_test_images.zip
+Challenge4_Test_Task1_GT.zip
+```
+
 ### Word Recognition
 
-Training Set
+The three files downloaded from [web](https://rrc.cvc.uab.es/?ch=4&com=downloads) for task 3 are 
+```
+ch4_training_word_images_gt.zip
+ch4_test_word_images_gt.zip
+Challenge4_Test_Task3_GT.txt
+```
+The three files are only needed for training word recognition models. Training text detection models does not require the three files.
 
-- [Training Set Word Images, along with Transcriptions Ground truth (40.5MB)](https://rrc.cvc.uab.es/?com=downloads&action=download&ch=4&f=aHR0cHM6Ly9ycmMuY3ZjLnVhYi5lcy8/Y29tPWRvd25sb2FkcyZhY3Rpb249ZG93bmxvYWQmZmlsZT1jaDRfdHJhaW5pbmdfd29yZF9pbWFnZXNfZ3Quemlw).- ~4468 cut out word images corresponding to the axis oriented bounding boxes of the words are provided along with a single text file with the relative coordinates of the bounding shape within each word image. Transcription ground truth is provided in a single txt file.
 
-Test Set
 
-- [Test Set Word Images (21.5MB)](https://rrc.cvc.uab.es/?com=downloads&action=download&ch=4&f=aHR0cHM6Ly9ycmMuY3ZjLnVhYi5lcy8/Y29tPWRvd25sb2FkcyZhY3Rpb249ZG93bmxvYWQmZmlsZT1jaDRfdGVzdF93b3JkX2ltYWdlc19ndC56aXA=).- 2077 cut out word images corresponding to the axis oriented bounding boxes of the words are provided along with a single text file with the relative coordinates of the bounding shape within each word image. You can submit your results for this Task over the images of the test set through the My Methods section.
 
-- [Test Set Ground Truth (49Kb)](https://rrc.cvc.uab.es/?com=downloads&action=download&ch=4&f=aHR0cHM6Ly9ycmMuY3ZjLnVhYi5lcy9kb3dubG9hZHMvQ2hhbGxlbmdlNF9UZXN0X1Rhc2szX0dULnR4dA==). - A single text file with the transcriptions of the 2077 images of the test set. Each line corresponds to an image of the test set.
 
 ### E2E
-Training Set
 
-
-[source](https://rrc.cvc.uab.es/?ch=4&com=downloads)
-
-- [Training Set Images (88.5MB)](https://rrc.cvc.uab.es/?com=downloads&action=download&ch=4&f=aHR0cHM6Ly9ycmMuY3ZjLnVhYi5lcy8/Y29tPWRvd25sb2FkcyZhY3Rpb249ZG93bmxvYWQmZmlsZT1jaDRfdHJhaW5pbmdfaW1hZ2VzLnppcA==).- 1000 images obtained with wearable cameras
-
-- [Training Set Vocabulary (16KB)](https://rrc.cvc.uab.es/?com=downloads&action=download&ch=4&f=aHR0cHM6Ly9ycmMuY3ZjLnVhYi5lcy8/Y29tPWRvd25sb2FkcyZhY3Rpb249ZG93bmxvYWQmZmlsZT1jaDRfdHJhaW5pbmdfdm9jYWJ1bGFyeS50eHQ=).- Vocabulary of all words (words of 3 characters or longer comprising only letters) appearing in the training set
-
-- [Training Set Per-image Vocabularies (504KB)](https://rrc.cvc.uab.es/?com=downloads&action=download&ch=4&f=aHR0cHM6Ly9ycmMuY3ZjLnVhYi5lcy8/Y29tPWRvd25sb2FkcyZhY3Rpb249ZG93bmxvYWQmZmlsZT1jaDRfdHJhaW5pbmdfdm9jYWJ1bGFyaWVzX3Blcl9pbWFnZS56aXA=).- Vocabularies of 100 words per image, comprising the words appearing in the image plus distractors
-
-- [Training Set Localisation and Transcription Ground Truth (157KB)](https://rrc.cvc.uab.es/?com=downloads&action=download&ch=4&f=aHR0cHM6Ly9ycmMuY3ZjLnVhYi5lcy8/Y29tPWRvd25sb2FkcyZhY3Rpb249ZG93bmxvYWQmZmlsZT1jaDRfdHJhaW5pbmdfbG9jYWxpemF0aW9uX3RyYW5zY3JpcHRpb25fZ3Quemlw).- 1000 text files with word level localisation and transcription ground truth
-
-Test Set
-
-- [Test Set Images (43.3MB)](https://rrc.cvc.uab.es/?com=downloads&action=download&ch=4&f=aHR0cHM6Ly9ycmMuY3ZjLnVhYi5lcy8/Y29tPWRvd25sb2FkcyZhY3Rpb249ZG93bmxvYWQmZmlsZT1jaDRfdGVzdF9pbWFnZXMuemlw).- 500 images obtained with wearable cameras. You can submit your results for this Task over the images of the test set through the My Methods section.
-
-- [Test Set Vocabulary (8KB)](https://rrc.cvc.uab.es/?com=downloads&action=download&ch=4&f=aHR0cHM6Ly9ycmMuY3ZjLnVhYi5lcy8/Y29tPWRvd25sb2FkcyZhY3Rpb249ZG93bmxvYWQmZmlsZT1jaDRfdGVzdF92b2NhYnVsYXJ5LnR4dA==).- Vocabulary of all words (words of 3 characters or longer comprising only letters) appearing in the test set
-
-- [Test Set Per-image Vocabularies (248KB)](https://rrc.cvc.uab.es/?com=downloads&action=download&ch=4&f=aHR0cHM6Ly9ycmMuY3ZjLnVhYi5lcy8/Y29tPWRvd25sb2FkcyZhY3Rpb249ZG93bmxvYWQmZmlsZT1jaDRfdGVzdF92b2NhYnVsYXJpZXNfcGVyX2ltYWdlLnppcA==).- Vocabularies of 100 words per image, comprising the words appearing in the image plus distractors
-
-- [Test Set Ground Truth (244Kb)](https://rrc.cvc.uab.es/?com=downloads&action=download&ch=4&f=aHR0cHM6Ly9ycmMuY3ZjLnVhYi5lcy9kb3dubG9hZHMvQ2hhbGxlbmdlNF9UZXN0X1Rhc2s0X0dULnppcA==). - 500 text files with text localisation bounding boxes for the images of the test set.
-
-Other
-
-- [Generic Vocabulary (796KB)](https://rrc.cvc.uab.es/?com=downloads&action=download&ch=4&f=aHR0cHM6Ly9ycmMuY3ZjLnVhYi5lcy8/Y29tPWRvd25sb2FkcyZhY3Rpb249ZG93bmxvYWQmZmlsZT1HZW5lcmljVm9jYWJ1bGFyeS50eHQ=).- A vocabulary of about 90k words derived from the dataset publicly available here. Please consult [1,2] for further information as well as the disclaimer in the vocabulary file itself.
-
-
-References
-1. M. Jaderberg, K. Simonyan, A. Vedaldi, and A. Zisserman, "Synthetic data and artificial neural networks for natural scene text recognition", arXiv preprint arXiv:1406.2227, 2014
-2. M. Jaderberg, K. Simonyan, A. Vedaldi, and A. Zisserman, "Reading Text in the Wild with Convolutional Neural Networks", arXiv preprint arXiv:1412.1842, 2014
+The nine files downloaded from [web](https://rrc.cvc.uab.es/?ch=4&com=downloads) for task 4 are the union of the four files in the text localization task (task 1) and five vocabulary files 
+```
+ch4_training_vocabulary.txt
+ch4_training_vocabularies_per_image.zip
+ch4_test_vocabulary.txt
+ch4_test_vocabularies_per_image.zip
+GenericVocabulary.txt
+```
+If you download a file named `Challenge4_Test_Task4_GT.zip`, please note that it is the same file as `Challenge4_Test_Task1_GT.zip`, except for its name. In this repository, we will use `Challenge4_Test_Task4_GT.zip` for ICDAR2015 dataset.
 
 </details>
 

--- a/docs/en/datasets/mlt2017.md
+++ b/docs/en/datasets/mlt2017.md
@@ -4,12 +4,63 @@ English | [中文](../../cn/datasets/mlt2017_CN.md)
 
 MLT (Multi-Lingual) 2017 [paper](https://ieeexplore.ieee.org/abstract/document/8270168)
 
-[download source](https://rrc.cvc.uab.es/?ch=8)
+[download source](https://rrc.cvc.uab.es/?ch=8&com=downloads). One need to register an account to download this dataset.
+
+<details>
+  <summary>Where to Download MLT 2017</summary>
+
+MLT 2017 dataset consists of two tasks. Task 1 is Text detection (Multi-Language Script) and Task 2 is Word Recognition.
+
+### Text Detection(Multi-script)
+
+The 11 files downloaded from [web](https://rrc.cvc.uab.es/?ch=8&com=downloads) for task 1 are 
+
+```
+ch8_training_images_x.zip(x from 1 to 8)
+ch8_validation_images.zip
+ch8_training_localization_transcription_gt_v2.zip
+ch8_validation_localization_transcription_gt_v2.zip
+```
+
+No need to download the Test Set.
+
+
+### Word Identification
+
+The 6 files downloaded from [web](https://rrc.cvc.uab.es/?ch=8&com=downloads) for task 2 are 
+```
+ ch8_training_word_images_gt_part_x.zip (x from 1 to 3)
+ ch8_validation_word_images_gt.zip
+ ch8_training_word_gt_v2.zip
+ ch8_validation_word_gt_v2.zip
+ ```
+
+</details>
 
 After downloading the files, place them under `[path-to-data-dir]` folder:
 ```
 path-to-data-dir/
   mlt2017/
+    # text detection
+    ch8_training_images_1.zip
+    ch8_training_images_2.zip
+    ch8_training_images_3.zip
+    ch8_training_images_4.zip
+    ch8_training_images_5.zip
+    ch8_training_images_6.zip
+    ch8_training_images_7.zip
+    ch8_training_images_8.zip
+    ch8_training_localization_transcription_gt_v2.zip
+    ch8_validation_images.zip
+    ch8_validation_localization_transcription_gt_v2.zip
+    # word recognition
+    ch8_training_word_images_gt_part_1.zip
+    ch8_training_word_images_gt_part_2.zip
+    ch8_training_word_images_gt_part_3.zip
+    ch8_training_word_gt_v2.zip
+    ch8_validation_word_images_gt.zip
+    ch8_validation_word_gt_v2.zip
+    
 ```
 
 [Back to README](../../../tools/dataset_converters/README.md)

--- a/mindocr/data/transforms/iaa_augment.py
+++ b/mindocr/data/transforms/iaa_augment.py
@@ -11,8 +11,6 @@ class IaaAugment:
 
     def __call__(self, data):
         aug = self._augmenter.to_deterministic()    # to augment an image and its keypoints identically
-        data['image'] = aug.augment_image(data['image'])
-
         if 'polys' in data:
             new_polys = []
             for poly in data['polys']:
@@ -21,5 +19,6 @@ class IaaAugment:
                 new_polys.append(np.array([[kp.x, kp.y] for kp in kps.keypoints]))
 
             data['polys'] = np.array(new_polys) if isinstance(data['polys'], np.ndarray) else new_polys
+        data['image'] = aug.augment_image(data['image'])
 
         return data

--- a/tools/convert_datasets.sh
+++ b/tools/convert_datasets.sh
@@ -15,7 +15,23 @@ DATASETS_DIR="../ocr_datasets" # the directory containing multiple ocr datasets 
 #     ch4_training_word_images_gt.zip
 #     Challenge4_Test_Task3_GT.zip
 #   mlt2017/
-#     mlt2017.zip
+#     ch8_training_images_1.zip
+#     ch8_training_images_2.zip
+#     ch8_training_images_3.zip
+#     ch8_training_images_4.zip
+#     ch8_training_images_5.zip
+#     ch8_training_images_6.zip
+#     ch8_training_images_7.zip
+#     ch8_training_images_8.zip
+#     ch8_training_localization_transcription_gt_v2.zip
+#     ch8_validation_images.zip
+#     ch8_validation_localization_transcription_gt_v2.zip
+#     ch8_training_word_images_gt_part_1.zip
+#     ch8_training_word_images_gt_part_2.zip
+#     ch8_training_word_images_gt_part_3.zip
+#     ch8_training_word_gt_v2.zip
+#     ch8_validation_word_images_gt.zip
+#     ch8_validation_word_gt_v2.zip
 #   syntext150k/
 #     syntext1/
 #       images.zip
@@ -134,32 +150,94 @@ else
           --label_dir $DIR/syntext2/annotations/syntext_word_eng.json \
           --output_path $DIR/syntext2/train_det_gt.txt
   fi
-
+fi
 
 ##########################mlt2017#########################
 DIR="$DATASETS_DIR/mlt2017"
 if  [ ! -d $DIR ] || [  ! "$(ls -A $DIR)"  ]; then
-  echo "MTL 2017 is Empty! Skipped."
+   echo "MLT2017 is Empty! Skipped."
 else
-  unzip $DIR/mlt2017.zip -d $DIR/
-  mv $DIR/mlt2017/images.zip $DIR/images.zip
-  mv $DIR/mlt2017/train.json $DIR/train.json
-  rm $DIR/mlt2017.zip
-  rm -rf $DIR/mlt2017/
-  unzip $DIR/images.zip -d $DIR/images/
-  rm $DIR/images.zip
+   unzip $DIR/ch8_training_images_1.zip -d $DIR/ch8_training_images/
+   rm $DIR/ch8_training_images_1.zip
+   unzip $DIR/ch8_training_images_2.zip -d $DIR/ch8_training_images/
+   rm $DIR/ch8_training_images_2.zip
+   unzip $DIR/ch8_training_images_3.zip -d $DIR/ch8_training_images/
+   rm $DIR/ch8_training_images_3.zip
+   unzip $DIR/ch8_training_images_4.zip -d $DIR/ch8_training_images/
+   rm $DIR/ch8_training_images_4.zip
+   unzip $DIR/ch8_training_images_5.zip -d $DIR/ch8_training_images/
+   rm $DIR/ch8_training_images_5.zip
+   unzip $DIR/ch8_training_images_6.zip -d $DIR/ch8_training_images/
+   rm $DIR/ch8_training_images_6.zip
+   unzip $DIR/ch8_training_images_7.zip -d $DIR/ch8_training_images/
+   rm $DIR/ch8_training_images_7.zip
+   unzip $DIR/ch8_training_images_8.zip -d $DIR/ch8_training_images/
+   rm $DIR/ch8_training_images_8.zip
 
+   unzip $DIR/ch8_training_localization_transcription_gt_v2.zip -d $DIR/ch8_training_localization_transcription_gt/
+   rm $DIR/ch8_training_localization_transcription_gt_v2.zip
+
+   unzip $DIR/ch8_validation_images.zip -d $DIR/ch8_validation_images/
+   rm $DIR/ch8_validation_images.zip
+
+   unzip $DIR/ch8_validation_localization_transcription_gt_v2.zip -d $DIR/ch8_validation_localization_transcription_gt/
+   rm $DIR/ch8_validation_localization_transcription_gt_v2.zip
+
+   unzip $DIR/ch8_training_word_images_gt_part_1.zip -d $DIR/ch8_training_word_images_gt/
+   rm $DIR/ch8_training_word_images_gt_part_1.zip
+   unzip $DIR/ch8_training_word_images_gt_part_2.zip -d $DIR/ch8_training_word_images_gt/
+   rm $DIR/ch8_training_word_images_gt_part_2.zip
+   unzip $DIR/ch8_training_word_images_gt_part_3.zip -d $DIR/ch8_training_word_images_gt/
+   rm $DIR/ch8_training_word_images_gt_part_3.zip
+
+   unzip $DIR/ch8_training_word_gt_v2.zip -d $DIR/ch8_training_word_gt/
+   rm $DIR/ch8_training_word_gt_v2.zip
+   unzip $DIR/ch8_validation_word_images_gt.zip -d $DIR/ch8_validation_word_images_gt/
+   rm $DIR/ch8_validation_word_images_gt.zip
+   unzip $DIR/ch8_validation_word_gt_v2.zip -d $DIR/ch8_validation_word_gt/
+   rm $DIR/ch8_validation_word_gt_v2.zip
+   
   if test -f "$DIR/train_det_gt.txt"; then
      echo "$DIR/train_det_gt.txt exists."
   else
      python tools/dataset_converters/convert.py \
           --dataset_name  mlt2017 \
           --task det \
-          --image_dir $DIR/images/MLT_train_images/ \
-          --label_dir $DIR/train.json \
+          --image_dir $DIR/ch8_training_images/ \
+          --label_dir $DIR/ch8_training_localization_transcription_gt/\
           --output_path $DIR/train_det_gt.txt
   fi
+  if test -f "$DIR/val_det_gt.txt"; then
+     echo "$DIR/val_det_gt.txt exists."
+  else
+     python tools/dataset_converters/convert.py \
+          --dataset_name  mlt2017 \
+          --task det \
+          --image_dir $DIR/ch8_validation_images/ \
+          --label_dir $DIR/ch8_validation_localization_transcription_gt/ \
+          --output_path $DIR/val_det_gt.txt
+  fi
+ 
 
+  if test -f "$DIR/train_rec_gt.txt"; then
+     echo "$DIR/train_rec_gt.txt exists."
+  else
+     python tools/dataset_converters/convert.py \
+        --dataset_name  mlt2017 \
+        --task rec \
+        --label_dir $DIR/ch8_training_word_gt/gt.txt \
+        --output_path $DIR/train_rec_gt.txt
+  fi
+  if test -f "$DIR/val_rec_gt.txt"; then
+     echo "$DIR/val_rec_gt.txt exists."
+  else
+    python tools/dataset_converters/convert.py \
+        --dataset_name  mlt2017 \
+        --task rec \
+        --label_dir $DIR/ch8_validation_word_gt/gt.txt \
+        --output_path $DIR/val_rec_gt.txt
+  fi
+fi
 ##########################total_text#########################
 DIR="$DATASETS_DIR/totaltext"
 if  [ ! -d $DIR ] || [  ! "$(ls -A $DIR)"  ]; then
@@ -192,3 +270,4 @@ else
           --label_dir $DIR/annotations/Test/ \
           --output_path $DIR/test_det_gt.txt
   fi
+fi

--- a/tools/dataset_converters/README.md
+++ b/tools/dataset_converters/README.md
@@ -2,7 +2,7 @@ English | [中文](README_CN.md)
 
 This document shows how to convert ocr annotation to the general format (not including LMDB) for model training. 
 
-You may also refer to [`convert_datasets.sh`](../../convert_datasets.sh) which is a quick solution for converting annotation files of all datasets under a given directory.
+You may also refer to [`convert_datasets.sh`](../convert_datasets.sh) which is a quick solution for converting annotation files of all datasets under a given directory.
 
 For downloading ocr datasets, you can refer to the instructions for [ICDAR2015](../../docs/en/datasets/icdar2015.md), [MLT2017](../../docs/en/datasets/mlt2017.md), [Syntext 150k](../../docs/en/datasets/syntext150k.md), [Total Text](../../docs/en/datasets/totaltext.md).
 

--- a/tools/dataset_converters/README_CN.md
+++ b/tools/dataset_converters/README_CN.md
@@ -2,9 +2,9 @@
 
 本文档展示了如何将OCR数据集的标注文件（不包括LMDB）转换为通用格式以进行模型训练。
 
-您也可以参考 [`convert_datasets.sh`](../../convert_datasets.sh)。这是将给定目录下所有数据集的标注文件转换为通用格式的Shell 脚本。
+您也可以参考 [`convert_datasets.sh`](../convert_datasets.sh)。这是将给定目录下所有数据集的标注文件转换为通用格式的Shell 脚本。
 
-要下载OCR数据集，您可以参考 [ICDAR2015](../../docs/en/datasets/icdar2015.md), [MLT2017](../../docs/en/datasets/mlt2017.md), [Syntext 150k](../../docs/en/datasets/syntext150k.md), [Total Text](../../docs/en/datasets/totaltext.md)的说明。
+要下载OCR数据集，您可以参考 [ICDAR2015](../../docs/cn/datasets/icdar2015_CN.md), [MLT2017](../../docs/cn/datasets/mlt2017_CN.md), [Syntext 150k](../../docs/cn/datasets/syntext150k_CN.md), [Total Text](../../docs/cn/datasets/totaltext_CN.md)的说明。
 
 ## 文本检测/端到端文本检测
 

--- a/tools/dataset_converters/mlt2017.py
+++ b/tools/dataset_converters/mlt2017.py
@@ -27,7 +27,7 @@ class MLT2017_Converter(object):
         if task == 'det':
             self._format_det_label(Path(image_dir), label_path, output_path)
         if task == 'rec':
-            raise ValueError("MLT 2017 dataset has no cropped word images and recognition labels.")
+            self._format_rec_label( label_path, output_path)
 
     def _format_det_label(self, image_dir: Path, label_path: Path, output_path: str):
         with open(output_path, 'w', encoding='utf-8') as out_file:
@@ -47,3 +47,16 @@ class MLT2017_Converter(object):
 
                 img_path = img_path.name if self._relative else str(img_path)
                 out_file.write(img_path + '\t' + json.dumps(label, ensure_ascii=False) + '\n')
+    def _format_rec_label(self, label_path, output_path):
+        with open(output_path, 'w') as outf:
+            with open(label_path, 'r') as f:
+                for line in f:
+                    # , may occur in text
+                    sep_index = line.find(',')
+                    img_path = line[:sep_index].strip().replace('\ufeff', '')
+                    label = line[sep_index+1:].strip().replace("\"", "")
+                    sep_index =label.find(',')
+                    language = label[:sep_index].strip().replace("\"", "")
+                    label = label[sep_index+1:].strip().replace("\"", "")
+                    
+                    outf.write(img_path + '\t' + language+ '\t' + label + '\n') 

--- a/tools/dataset_converters/totaltext.py
+++ b/tools/dataset_converters/totaltext.py
@@ -44,7 +44,6 @@ class TOTALTEXT_Converter(object):
                                                         "").split(', ')
                         assert len(tmp), f"parse error for {tmp}."
                         if len(tmp)<4 or len(line_saver)>0:
-                            import pdb; pdb.set_trace()
                             line_saver +=line
                             new_splits = line_saver.strip("\n\r").replace("\xef\xbb\xbf","").split(', ')
                             if len(new_splits) <4:


### PR DESCRIPTION
Thank you for your contribution to the MindOCR repo.
Before submitting this PR, please make sure:

- [x] You have read the [Contributing Guidelines on pull requests](https://github.com/mindspore-lab/mindcv/blob/main/CONTRIBUTING.md)
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved terminology
- [ ] You have added unit tests

## Motivation

(Write your motivation for proposed changes here.)

## Test Plan

(How should this PR be tested? Do you require special setup to run the test or repro the fixed bug?)

## Related Issues and PRs

(Is this PR part of a group of changes? Link the other relevant PRs and Issues here. Use https://help.github.com/en/articles/closing-issues-using-keywords for help on GitHub syntax)


1. README.md and README_CN.md, increases the `Dataset` section, introducing the method to download and convert datasets;
2. fix some link errors:
3. fix convert_datasets.sh missing `fi` problem;
4. fix IaaAugment bug;
5. fix tools/dataset_converters/totaltext.py bug