### PR TITLE
support feature extraction of mindcv backbone: resnet and mobiletnet v3

### DIFF
--- a/configs/det/dbnet/db_r50_icdar15.yaml
+++ b/configs/det/dbnet/db_r50_icdar15.yaml
@@ -11,10 +11,8 @@ model:
   type: det
   transform: null
   backbone:
-    name: mindcv.resnet50   # Mobilenet v3: mindcv.mobilenet_v3_small_100
+    name: det_resnet50
     pretrained: True
-    features_only: True
-    out_indices: [1, 2, 3, 4]  # MobileNet v3: [1, 3, 7, 12]
   neck:
     name: DBFPN
     out_channels: 256

--- a/configs/det/dbnet/db_r50_icdar15.yaml
+++ b/configs/det/dbnet/db_r50_icdar15.yaml
@@ -11,8 +11,10 @@ model:
   type: det
   transform: null
   backbone:
-    name: det_resnet50
+    name: mindcv.resnet50   # Mobilenet v3: mindcv.mobilenet_v3_small_100
     pretrained: True
+    features_only: True
+    out_indices: [1, 2, 3, 4]  # MobileNet v3: [1, 3, 7, 12]
   neck:
     name: DBFPN
     out_channels: 256

--- a/mindocr/models/backbones/builder.py
+++ b/mindocr/models/backbones/builder.py
@@ -44,7 +44,7 @@ def build_backbone(name, **kwargs):
         #TODO: load pretrained weights
 
     elif 'mindcv' in name:
-        # TODO: update mindcv to get list of feature tensors, by adding feature_only parameter and out_indices to extract intermediate features.
+        # you can add `feature_only` parameter and `out_indices` in kwargs to extract intermediate features.
         backbone = MindCVBackboneWrapper(name, **kwargs)
     else:
         raise ValueError(f'Invalid backbone name: {name}, supported backbones are: {list_backbones()}')

--- a/mindocr/models/backbones/mindcv_models/_feature.py
+++ b/mindocr/models/backbones/mindcv_models/_feature.py
@@ -1,0 +1,118 @@
+from collections import OrderedDict
+from typing import Any, Dict, Iterable, List, Tuple
+
+import mindspore.nn as nn
+from mindspore import Tensor
+
+
+def _cell_list(net: nn.Cell, flatten_sequential: bool = False) -> Iterable[Tuple[str, str, nn.Cell]]:
+    """Yield the partially flattened cell list from the model, together with its new name and old name
+
+    Args:
+        net (nn.Cell): Network need to be partially flattened
+        flatten_sequential (bool): Flatten the inner-layer of the sequential cell. Default: False.
+
+    Returns:
+        iterator[tuple[str, str, nn.Cell]]: The new name, the old name and corresponding cell
+    """
+    for name, cell in net.name_cells().items():
+        if flatten_sequential and isinstance(cell, nn.SequentialCell):
+            for child_name, child_cell in cell.name_cells().items():
+                combined = [name, child_name]
+                yield "_".join(combined), ".".join(combined), child_cell
+        else:
+            yield name, name, cell
+
+
+def _get_return_layers(feature_info: Dict[str, Any], out_indices: List[int]) -> Dict[str, int]:
+    """Create a dict storing the "layer_name - layer_id" pair that need to be extracted"""
+    return_layers = dict()
+    for i, x in enumerate(feature_info):
+        if i in out_indices:
+            return_layers[x["name"]] = i
+    return return_layers
+
+
+class FeatureExtractWrapper(nn.Cell):
+    """A wrapper of the original model, aims to perform the feature extraction at each stride.
+    Basically, it performs 3 steps: 1. extract the return node name from the network's property
+    `feature_info`; 2. partially flatten the network architecture if network's attribute `flatten_sequential`
+    is True; 3. rebuild the forward steps and output the features based on the return node name.
+
+    It also provide a property `out_channels` in the wrapped model, return the number of features at each output
+    layer. This propery is usually used for the downstream tasks, which requires feature infomation at network
+    build stage.
+
+    It should be note that to apply this wrapper, there is a strong assumption that each of the outmost cell
+    are registered in the same order as they are used. And there should be no reuse of each cell, even for the `ReLU`
+    cell. Otherwise, the returned result may not be correct.
+
+    And it should be also note that it basically rebuild the model. So the default checkpoint parameter cannot be loaded
+    correctly once that model is wrapped. To use the pretrained weight, please load the weight first and then use this
+    wrapper to rebuild the model.
+
+    Args:
+        net (nn.Cell): The model need to be wrapped.
+        out_indices (list[int]): The indicies of the output features. Default: [0, 1, 2, 3, 4]
+    """
+
+    def __init__(self, net: nn.Cell, out_indices: List[int] = [0, 1, 2, 3, 4]) -> None:
+        super().__init__(auto_prefix=False)
+
+        feature_info = self._get_feature_info(net)
+        flatten_sequetial = getattr(net, "flatten_sequential", False)
+        cells = _cell_list(net, flatten_sequential=flatten_sequetial)
+        return_layers = _get_return_layers(feature_info, out_indices)
+        self.net, updated_return_layers = self._create_net(cells, return_layers)
+
+        # calculate the return index
+        self.return_index = list()
+        for i, name in enumerate(self.net.name_cells().keys()):
+            if name in updated_return_layers:
+                self.return_index.append(i)
+
+        # calculate the out_channels
+        self._out_channels = list()
+        for i in return_layers.values():
+            self._out_channels.append(feature_info[i]["chs"])
+
+    @property
+    def out_channels(self):
+        """The output channels of the model, filtered by the out_indices.
+        """
+        return self._out_channels
+
+    def construct(self, x: Tensor) -> List[Tensor]:
+        return self._collect(x)
+
+    def _get_feature_info(self, net: nn.Cell) -> Dict[str, Any]:
+        try:
+            feature_info = getattr(net, "feature_info")
+        except AttributeError:
+            raise
+        return feature_info
+
+    def _create_net(
+        self, cells: Iterable[Tuple[str, str, nn.Cell]], return_layers: Dict[str, int]
+    ) -> Tuple[nn.SequentialCell, Dict[str, int]]:
+        layers = OrderedDict()
+        updated_return_layers = dict()
+        remaining = set(return_layers.keys())
+        for new_name, old_name, module in cells:
+            layers[new_name] = module
+            if old_name in remaining:
+                updated_return_layers[new_name] = return_layers[old_name]
+                remaining.remove(old_name)
+            if not remaining:
+                break
+
+        net = nn.SequentialCell(layers)
+        return net, updated_return_layers
+
+    def _collect(self, x: Tensor) -> List[Tensor]:
+        out = list()
+        for i, cell in enumerate(self.net.cell_list):
+            x = cell(x)
+            if i in self.return_index:
+                out.append(x)
+        return out

--- a/mindocr/models/backbones/mindcv_models/mobilenet_v3.py
+++ b/mindocr/models/backbones/mindcv_models/mobilenet_v3.py
@@ -168,6 +168,8 @@ class MobileNetV3(nn.Cell):
             nn.BatchNorm2d(input_channels),
             nn.HSwish(),
         ]
+        total_reduction = 2
+        self.feature_info = [dict(chs=input_channels, reduction=total_reduction, name=f'features.{len(features) - 1}')]
         # Building bottleneck blocks.
         for k, e, c, se, nl, s in bottleneck_setting:
             exp_channels = make_divisible(alpha * e, round_nearest)
@@ -175,6 +177,8 @@ class MobileNetV3(nn.Cell):
             features.append(Bottleneck(input_channels, exp_channels, output_channels,
                                        kernel_size=k, stride=s, activation=nl, use_se=se))
             input_channels = output_channels
+            total_reduction *= s
+            self.feature_info.append(dict(chs=input_channels, reduction=total_reduction, name=f'features.{len(features) - 1}'))
         # Building last point-wise conv layers.
         output_channels = input_channels * 6
         features.extend([
@@ -182,6 +186,8 @@ class MobileNetV3(nn.Cell):
             nn.BatchNorm2d(output_channels),
             nn.HSwish(),
         ])
+        self.feature_info.append(dict(chs=output_channels, reduction=total_reduction, name=f'features.{len(features) - 1}'))
+        self.flatten_sequential = True
         self.features = nn.SequentialCell(features)
 
         self.pool = GlobalAvgPooling()

--- a/mindocr/models/backbones/mindcv_models/model_factory.py
+++ b/mindocr/models/backbones/mindcv_models/model_factory.py
@@ -1,7 +1,9 @@
 import os
+from typing import List
 
 from mindspore import load_checkpoint, load_param_into_net
 
+from ._feature import FeatureExtractWrapper
 from .registry import is_model, model_entrypoint
 
 __all__ = ["create_model"]
@@ -13,7 +15,9 @@ def create_model(
     pretrained=False,
     in_channels: int = 3,
     checkpoint_path: str = "",
-    ema=False,
+    ema: bool = False,
+    features_only: bool = False,
+    out_indices: List[int] = [0, 1, 2, 3, 4],
     **kwargs,
 ):
     r"""Creates model by name.
@@ -25,6 +29,9 @@ def create_model(
         in_channels (int): The input channels. Default: 3.
         checkpoint_path (str): The path of checkpoint files. Default: "".
         ema (bool): Whether use ema method. Default: False.
+        features_only (bool): Output the features at different strides instead. Default: False
+        out_indices (list[int]): The indicies of the output features when `features_only` is `True`.
+            Default: [0, 1, 2, 3, 4]
     """
 
     if checkpoint_path != "" and pretrained:
@@ -55,5 +62,12 @@ def create_model(
             raise ValueError("chekpoint_param does not contain ema_parameter, please set ema is False.")
         else:
             load_param_into_net(model, checkpoint_param)
+
+    if features_only:
+        # wrap the model, output the feature pyramid instead
+        try:
+            model = FeatureExtractWrapper(model, out_indices=out_indices)
+        except AttributeError as e:
+            raise RuntimeError(f"`feature_only` is not implemented for `{model_name}` model.") from e
 
     return model

--- a/mindocr/models/backbones/mindcv_models/resnet.py
+++ b/mindocr/models/backbones/mindcv_models/resnet.py
@@ -197,11 +197,13 @@ class ResNet(nn.Cell):
                                stride=2, pad_mode="pad", padding=3)
         self.bn1 = norm(self.input_channels)
         self.relu = nn.ReLU()
+        self.feature_info = [dict(chs=self.input_channels, reduction=2, name="relu")]
+
         self.max_pool = nn.MaxPool2d(kernel_size=3, stride=2, pad_mode="same")
-        self.layer1 = self._make_layer(block, 64, layers[0])
-        self.layer2 = self._make_layer(block, 128, layers[1], stride=2)
-        self.layer3 = self._make_layer(block, 256, layers[2], stride=2)
-        self.layer4 = self._make_layer(block, 512, layers[3], stride=2)
+        self.layer1 = self._make_layer(block, 64, layers[0], name="layer1", reduction=4)
+        self.layer2 = self._make_layer(block, 128, layers[1], stride=2, name="layer2", reduction=8)
+        self.layer3 = self._make_layer(block, 256, layers[2], stride=2, name="layer3", reduction=16)
+        self.layer4 = self._make_layer(block, 512, layers[3], stride=2, name="layer4", reduction=32)
 
         self.pool = GlobalAvgPooling()
         self.num_features = 512 * block.expansion
@@ -235,6 +237,8 @@ class ResNet(nn.Cell):
         channels: int,
         block_nums: int,
         stride: int = 1,
+        name: str = "",
+        reduction: int = 1,
     ) -> nn.SequentialCell:
         """build model depending on cfgs"""
         down_sample = None
@@ -269,6 +273,8 @@ class ResNet(nn.Cell):
                     norm=self.norm
                 )
             )
+
+        self.feature_info.append(dict(chs=self.input_channels, reduction=reduction, name=name))
 
         return nn.SequentialCell(layers)
 

--- a/mindocr/models/backbones/mindcv_wrapper.py
+++ b/mindocr/models/backbones/mindcv_wrapper.py
@@ -1,57 +1,76 @@
+from typing import List
 import numpy as np
-from . import mindcv_models
 import mindspore as ms
 from mindspore import ops
 from mindspore import nn
 from mindspore import load_checkpoint, load_param_into_net
+from . import mindcv_models
+
 
 class MindCVBackboneWrapper(nn.Cell):
     '''
     It reuses the forward_features interface in mindcv models. Please check where the features are extracted.
-    Only support forward the feature of the last layer of the backbone currently.
 
     Note: text recognition models like CRNN expects output feature in shape [bs, c, h, w]. but some models in mindcv
     like ViT output features in shape [bs, c]. please check and pick accordingly.
 
+    Args:
+        pretrained (bool): Whether the model backbone is pretrained. Default; True
+        checkpoint_path (str): The path of checkpoint files. Default: "".
+        features_only (bool): Output the features at different strides instead. Default: False
+        out_indices (list[int]): The indicies of the output features when `features_only` is `True`.
+             Default: [0, 1, 2, 3, 4]
+
     Example:
         network = MindCVBackboneWrapper('resnet50', pretrained=True)
     '''
-    def __init__(self, name, pretrained=True, ckpt_path=None, **kwargs):
+    def __init__(self, name, pretrained=True, ckpt_path=None, features_only: bool = False, out_indices: List[int] = [0, 1, 2, 3, 4], **kwargs):
         super().__init__()
-
-        #self.out_indices = out_indices
-        #self.out_channels =[ch*block.expansion for ch in [64, 128, 256, 512]]
+        self.features_only = features_only
 
         model_name = name.replace('@mindcv', "").replace("mindcv.", "")
-        network = mindcv_models.create_model(model_name, pretrained=pretrained)
-        # for local checkpaoint
+        network = mindcv_models.create_model(model_name, pretrained=pretrained, features_only=features_only, out_indices=out_indices)
+        # for local checkpoint
         if ckpt_path is not None:
             checkpoint_param = load_checkpoint(ckpt_path)
             load_param_into_net(network, checkpoint_param)
 
-        # TODO: add include_top or feature_only param in mindcv
-        if hasattr(network, 'classifier'):
-            del network.classifier  # remove the original header to avoid confusion
+        if not self.features_only:
+            if hasattr(network, 'classifier'):
+                del network.classifier  # remove the original header to avoid confusion
 
-        self.network = network
-        # probe to get out_channels
-        #network.eval()
-        # TODO: get image input size from default cfg
-        x = ms.Tensor(np.random.rand(2, 3, 224, 224), dtype=ms.float32)
-        h = network.forward_features(x)
-        h = ops.stop_gradient(h)
-        self.out_channels = h.shape[1]
+            self.network = network
+            # probe to get out_channels
+            #network.eval()
+            # TODO: get image input size from default cfg
+            x = ms.Tensor(np.random.rand(2, 3, 224, 224), dtype=ms.float32)
+            h = network.forward_features(x)
+            h = ops.stop_gradient(h)
+            self.out_channels = h.shape[1]
 
-        print(f'INFO: Load MindCV Backbone {model_name}, the output features shape for input 224x224 is {h.shape}. \n\tProbed out_channels : ', self.out_channels )
+            print(f'INFO: Load MindCV Backbone {model_name}, the output features shape for input 224x224 is {h.shape}. \n\tProbed out_channels : ', self.out_channels )
+        else:
+            self.network = network
+            self.out_channels = self.network.out_channels
+            print(f'INFO: Load MindCV Backbone {model_name} with feature index {out_indices}, output channels: {self.out_channels}' )
+            
 
     def construct(self, x):
-        features = self.network.forward_features(x)
-
-        return [features]
+        if self.features_only:
+            features = self.network(x)
+            return features
+        else:
+            features = self.network.forward_features(x)
+            return [features]
 
 if __name__=='__main__':
-    #model = MindCVBackboneWrapper('mindcv.vit_b_32_224', pretrained=False)
     model = MindCVBackboneWrapper('mindcv.resnet50', pretrained=False)
     x = ms.Tensor(np.random.rand(2, 3, 224, 224), dtype=ms.float32)
     ftr = model(x)
     print(ftr[0].shape)
+
+    model = MindCVBackboneWrapper('mindcv.resnet50', pretrained=False, features_only=True, out_indices=[1, 2, 3, 4])
+    x = ms.Tensor(np.random.rand(2, 3, 224, 224), dtype=ms.float32)
+    ftr = model(x)
+    for x in ftr:
+        print(x.shape)


### PR DESCRIPTION
Support intermediate feature extractions using backbones from mindcv (resnet and mobilenetv3). 
It is migrated fro this [PR](https://github.com/mindspore-lab/mindcv/pull/605)
You need to add `features_only` and `out_indices` in backbone configuration, to extract the feature pyramid. The examples is shown in the modified `db_r50_icdar15.yaml`

Thank you for your contribution to the MindOCR repo.
Before submitting this PR, please make sure:

- [x] You have read the [Contributing Guidelines on pull requests](https://github.com/mindspore-lab/mindcv/blob/main/CONTRIBUTING.md)
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved terminology
- [ ] You have added unit tests

## Motivation

(Write your motivation for proposed changes here.)

## Test Plan

(How should this PR be tested? Do you require special setup to run the test or repro the fixed bug?)

## Related Issues and PRs

(Is this PR part of a group of changes? Link the other relevant PRs and Issues here. Use https://help.github.com/en/articles/closing-issues-using-keywords for help on GitHub syntax)
