### PR TITLE
use proxy when upgrading pip on modelart

### DIFF
--- a/tools/modelarts_adapter/modelarts.py
+++ b/tools/modelarts_adapter/modelarts.py
@@ -83,7 +83,7 @@ def install_packages(req_path: str='requirements.txt') -> None:
     #requirement_txt = os.path.join(project_dir, "requirements.txt")
     print('INFO: Packages to be installed: ', req_path)
     subprocess.check_call(
-        [sys.executable, "-m", "pip", "install", "--upgrade", "pip"]
+        [sys.executable, "-m", "pip", "install", "-i", url, "--upgrade", "pip"]
     )
     subprocess.check_call(
         [sys.executable, "-m", "pip", "install", "-i", url, "-r", req_path]


### PR DESCRIPTION
Pip cannot be upgraded successfully on modelart due to networking issue

Thank you for your contribution to the MindOCR repo.
Before submitting this PR, please make sure:

- [x] You have read the [Contributing Guidelines on pull requests](https://github.com/mindspore-lab/mindcv/blob/main/CONTRIBUTING.md)
- [x] Your code builds clean without any errors or warnings
- [x]  You are using approved terminology
- [ ] You have added unit tests

## Motivation

(Write your motivation for proposed changes here.)

## Test Plan

(How should this PR be tested? Do you require special setup to run the test or repro the fixed bug?)

## Related Issues and PRs

(Is this PR part of a group of changes? Link the other relevant PRs and Issues here. Use https://help.github.com/en/articles/closing-issues-using-keywords for help on GitHub syntax)
