### PR TITLE
fix export.py to support loading either local or online ckpt

### DIFF
--- a/tests/ut/test_mindir_export.py
+++ b/tests/ut/test_mindir_export.py
@@ -12,7 +12,7 @@ def test_mindir_infer(name):
     if 'db' in name:
         task = 'det'
 
-    export(name, task, pretrained=True)
+    export(name, task)
 
     fn = f"{name}.mindir"
 

--- a/tools/export.py
+++ b/tools/export.py
@@ -1,10 +1,14 @@
 '''
+The online ckpt files are downloaded from https://download.mindspore.cn/toolkits/mindocr/
 Usage:
-    To export all trained models from ckpt to mindir as listed in configs/, run
-       $  python tools/export.py
+    To export all trained models from online ckpt to mindir as listed in configs/, run
+       $ python tools/export.py
 
-    To export a sepecific model, taking dbnet for example, run
-       $ python tools/export.py --model_name dbnet_resnet50  --save_dir
+    To export a specific model by downloading online ckpt, taking dbnet_resnet50 for example, run
+       $ python tools/export.py --model_name dbnet_resnet50
+
+    To export a specific model by loading local ckpt, taking dbnet_resnet50 for example, run
+       $ python tools/export.py --model_name dbnet_resnet50 --local_ckpt_path /path/to/local_ckpt
 '''
 import sys
 import os
@@ -17,10 +21,12 @@ from mindocr import list_models, build_model
 import numpy as np
 
 
-def export(name, task='rec', pretrained=True, ckpt_load_path="", save_dir=""):
+def export(name, task='rec', local_ckpt_path="", save_dir=""):
     ms.set_context(mode=ms.GRAPH_MODE) #, device_target='Ascend')
-
-    net = build_model(name, pretrained=True)
+    if local_ckpt_path:
+        net = build_model(name, pretrained=False, ckpt_load_path=local_ckpt_path)
+    else:
+        net = build_model(name, pretrained=True)
     net.set_train(False)
 
     # TODO: extend input shapes for more models
@@ -48,6 +54,17 @@ def str2bool(v):
     else:
         raise argparse.ArgumentTypeError("Boolean value expected.")
 
+def check_args(args):
+    if args.local_ckpt_path:  # load local ckpt
+        if not args.model_name:
+            raise ValueError("Arg 'model_name' is empty. Please set 'model_name' if 'local_ckpt_path' is not None.")
+        if args.model_name not in list_models():
+            raise ValueError(f"Invalid 'model_name': {args.model_name}. 'model_name' must be one of names in {list_models()}.")
+        if not os.path.isfile(args.local_ckpt_path):
+            raise ValueError(f"No such ckpt file in this path: {args.local_ckpt_path}.")
+    else:  # download online ckpt
+        if args.model_name and args.model_name not in list_models():
+            raise ValueError(f"Invalid 'model_name': {args.model_name}. 'model_name' must be empty or one of names in {list_models()}.")
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser("Convert model checkpoint to mindir format.")
@@ -57,15 +74,10 @@ if __name__ == '__main__':
         default="",
         help='Name of the model to convert, choices: [crnn_resnet34, crnn_vgg7, dbnet_resnet50, ""]. You can lookup the name by calling mindocr.list_models(). If "", all models in list_models() will be converted.')
     parser.add_argument(
-        '--pretrained',
-        type=str2bool, nargs='?', const=True,
-        default=True,
-        help='Whether download and load the pretrained checkpoint into network.')
-    parser.add_argument(
-        '--ckpt_load_path',
+        '--local_ckpt_path',
         type=str,
         default="",
-        help='Path to a local checkpoint. No need to set it if pretrained is True. If set, network weights will be loaded using this checkpoint file')
+        help='Path to a local checkpoint. If set, export a specific model by loading local ckpt. Otherwise, export all models or a specific model by downloading online ckpt.')
     parser.add_argument(
         '--save_dir',
         type=str,
@@ -73,15 +85,15 @@ if __name__ == '__main__':
         help='Dir to save the exported model')
 
     args = parser.parse_args()
-    mn = args.model_name
+    check_args(args)
 
-    if mn =="":
-        names = list_models()
+    if args.model_name == "":
+        model_names = list_models()
     else:
-        names = [mn]
+        model_names = [args.model_name]
 
-    for n in names:
+    for n in model_names:
         task = 'rec'
-        if 'db' in n:
+        if 'db' in n or 'east' in n:
             task = 'det'
-        export(n, task, args.pretrained, args.ckpt_load_path, args.save_dir)
+        export(n, task, args.local_ckpt_path, args.save_dir)


### PR DESCRIPTION
Thank you for your contribution to the MindOCR repo.
Before submitting this PR, please make sure:

- [x] You have read the [Contributing Guidelines on pull requests](https://github.com/mindspore-lab/mindcv/blob/main/CONTRIBUTING.md)
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved terminology
- [ ] You have added unit tests

## Motivation

Two ways to load ckpt and export mindir file:
(1) If do not specify `local_ckpt_path`, download online ckpt from url in default_cfg.
(2) If specify `local_ckpt_path` and `model_name`, load local ckpt for exporting a specific model.
