### PR TITLE
fix the formatting error

### DIFF
--- a/mindocr/utils/callbacks.py
+++ b/mindocr/utils/callbacks.py
@@ -236,7 +236,7 @@ class EvalSaveCallback(Callback):
         if not data_sink_mode and cur_step_in_epoch % self.log_interval == 0:
             opt = cb_params.train_network.optimizer
             learning_rate = opt.learning_rate
-            cur_lr = learning_rate(opt.global_step - 1).asnumpy()
+            cur_lr = learning_rate(opt.global_step - 1).asnumpy().squeeze()
             per_step_time = (time.time() - self.step_start_time) * 1000 / self.log_interval
             fps = self.batch_size * 1000 / per_step_time
             loss = self._losses[-1].asnumpy()


### PR DESCRIPTION
Somehow `cur_lr` will be `[0.111]` instead of `0.111` in some cases. Which will raise the formatting error in the logging message from PR #272. This is a fix


Thank you for your contribution to the MindOCR repo.
Before submitting this PR, please make sure:

- [ ] You have read the [Contributing Guidelines on pull requests](https://github.com/mindspore-lab/mindcv/blob/main/CONTRIBUTING.md)
- [ ] Your code builds clean without any errors or warnings
- [ ] You are using approved terminology
- [ ] You have added unit tests

## Motivation

(Write your motivation for proposed changes here.)

## Test Plan

(How should this PR be tested? Do you require special setup to run the test or repro the fixed bug?)

## Related Issues and PRs

(Is this PR part of a group of changes? Link the other relevant PRs and Issues here. Use https://help.github.com/en/articles/closing-issues-using-keywords for help on GitHub syntax)
