### PR TITLE
Support relative path of config file in ModelArt and fix bug

### DIFF
--- a/tools/modelarts_adapter/modelarts.py
+++ b/tools/modelarts_adapter/modelarts.py
@@ -119,7 +119,12 @@ def upload_data(src: str, s3_path: str) -> None:
 def modelarts_setup(args):
     if args.enable_modelarts:
         cur_dir = os.path.dirname(os.path.abspath(__file__))
-        req_path = os.path.join(cur_dir, '../../requirements/modelarts.txt')
+
+        # change relative path of configure file to absolute
+        if not os.path.isabs(args.config):
+            args.config = os.path.abspath(os.path.join(cur_dir, '../../', args.config))
+
+        req_path = os.path.abspath(os.path.join(cur_dir, '../../requirements/modelarts.txt'))
         install_packages(req_path)
         return True
     return False

--- a/tools/train.py
+++ b/tools/train.py
@@ -45,7 +45,7 @@ from mindocr.utils.ema import EMA
 
 def main(cfg):
     # init env
-    ms.set_context(mode=cfg.system.mode, device_id=6)
+    ms.set_context(mode=cfg.system.mode)
     if cfg.system.distribute:
         init()
         device_num = get_group_size()


### PR DESCRIPTION
- Support relative path of config file in ModelArt (e.g., config=configs/rec/crnn/crnn_resnet34.yaml)
- Remove the hard code of device id from #279 

Thank you for your contribution to the MindOCR repo.
Before submitting this PR, please make sure:

- [ ] You have read the [Contributing Guidelines on pull requests](https://github.com/mindspore-lab/mindcv/blob/main/CONTRIBUTING.md)
- [ ] Your code builds clean without any errors or warnings
- [ ] You are using approved terminology
- [ ] You have added unit tests

## Motivation

(Write your motivation for proposed changes here.)

## Test Plan

(How should this PR be tested? Do you require special setup to run the test or repro the fixed bug?)

## Related Issues and PRs

(Is this PR part of a group of changes? Link the other relevant PRs and Issues here. Use https://help.github.com/en/articles/closing-issues-using-keywords for help on GitHub syntax)
