### PR TITLE
support non-strict checkpoint loading

### DIFF
--- a/mindocr/models/backbones/mindcv_models/download.py
+++ b/mindocr/models/backbones/mindcv_models/download.py
@@ -140,7 +140,7 @@ class DownLoad:
         # Check if the file is exists.
         if os.path.isfile(file_path):
             if not md5 or self.check_md5(file_path, md5):
-                return
+                return file_path
 
         # Download the file.
         try:
@@ -157,6 +157,8 @@ class DownLoad:
                     ssl._create_default_https_context = ssl.create_default_context
             else:
                 raise e
+        
+        return file_path
 
     def download_and_extract_archive(
         self,

--- a/mindocr/models/utils/load_model.py
+++ b/mindocr/models/utils/load_model.py
@@ -1,26 +1,74 @@
-from typing import Callable, Dict, List, Optional
 import os
+from typing import Callable, Dict, Optional
+
 from mindspore import load_checkpoint, load_param_into_net
-from ..backbones.mindcv_models.utils import load_pretrained
+
+from ..backbones.mindcv_models.utils import auto_map, download_pretrained
 
 
-__all__ = ['load_model']
+__all__ = ["load_model", "drop_inconsistent_shape_parameters"]
 
 
-def load_model(network, load_from: str, filter_fn: Optional[Callable[[Dict], Dict]] = None):
-    '''
-    network: network
-    load_from: can be url or local path to a checkpoint that will be loaded to the network.
-    '''
-    if load_from is not None:
-        if load_from[:4] == 'http':
-            url_cfg = {'url': load_from}
-            load_pretrained(network, url_cfg, filter_fn=filter_fn)
+def drop_inconsistent_shape_parameters(model, param_dict):
+    updated_param_dict = dict()
+    for param in model.get_parameters():
+        name = param.name
+        if name in param_dict:
+            if param_dict[name].shape == param.shape:
+                updated_param_dict[name] = param_dict[name]
+            else:
+                print(
+                    f"WARNING: Dropping checkpoint parameter `{name}` with shape `{param_dict[name].shape}`, which is inconsistent with cell shape `{param.shape}`"
+                )
         else:
-            assert os.path.exists(load_from), f'Failed to load checkpoint. {load_from} NOT exist. \n Please check the path and set it in `eval-ckpt_load_path` or `model-pretrained` in the yaml config file '
-            params = load_checkpoint(load_from)
-            if filter_fn is not None:
-                params = filter_fn(params)
-            load_param_into_net(network, params)
+            print(f"WARNING: Cannot find checkpoint parameter `{name}`.")
+    return updated_param_dict
 
-            print(f'INFO: Finish loading model checkoint from {load_from}. If no parameter fail-load warning displayed, all checkpoint params have been successfully loaded.')
+
+def load_model(
+    network,
+    load_from: Optional[str] = None,
+    filter_fn: Optional[Callable[[Dict], Dict]] = None,
+    auto_mapping: bool = False,
+    strict: bool = False,
+):
+    """
+    Load the checkpoint into the model
+
+    Args:
+        network: network
+        load_from: a string that can be url or local path to a checkpoint, that will be loaded to the network.
+        filter_fn: a function filtering the parameters that will be loading into the network. If it is None, all parameters will be loaded.
+        auto_mapping: when it is True, then load the paramters even if the names are slightly different
+        strict: If it is true, then the shape and the type of the parameters in the checkpoint and the network should be consistent
+            raise exception if they do not match.
+    """
+    if load_from is None:
+        return
+
+    if load_from[:4] == "http":
+        url_cfg = {"url": load_from}
+        local_ckpt_path = download_pretrained(url_cfg)
+
+    assert local_ckpt_path and os.path.exists(local_ckpt_path), (
+        f"Failed to load checkpoint. `{local_ckpt_path}` NOT exist. \n"
+        "Please check the path and set it in `eval-ckpt_load_path` or `model-pretrained` in the yaml config file "
+    )
+
+    params = load_checkpoint(local_ckpt_path)
+
+    if filter_fn is not None:
+        params = filter_fn(params)
+
+    if auto_mapping:
+        params = auto_map(network, params)
+
+    if not strict:
+        params = drop_inconsistent_shape_parameters(network, params)
+
+    load_param_into_net(network, params, strict_load=strict)
+
+    print(
+        f"INFO: Finish loading model checkoint from {load_from}. "
+        "If no parameter fail-load warning displayed, all checkpoint params have been successfully loaded."
+    )


### PR DESCRIPTION
1. Support non-strict way of loading checkpoint like Pytorch.  e.g, skip loading the parameters if the shape is not same, instead of raising exception. 
2. Refactor funcs in mindcv_models.utils.py, such that it is reusable in utility `load_model` in `load_model.py`.
Thank you for your contribution to the MindOCR repo.
Before submitting this PR, please make sure:

- [x] You have read the [Contributing Guidelines on pull requests](https://github.com/mindspore-lab/mindcv/blob/main/CONTRIBUTING.md)
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved terminology
- [ ] You have added unit tests

## Motivation

(Write your motivation for proposed changes here.)

## Test Plan

(How should this PR be tested? Do you require special setup to run the test or repro the fixed bug?)

## Related Issues and PRs

(Is this PR part of a group of changes? Link the other relevant PRs and Issues here. Use https://help.github.com/en/articles/closing-issues-using-keywords for help on GitHub syntax)
