### PR TITLE
modify transform op output variable name to avoid mindir conversion bug

### DIFF
--- a/mindocr/models/base_model.py
+++ b/mindocr/models/base_model.py
@@ -47,12 +47,10 @@ class BaseModel(nn.Cell):
 
     def construct(self, x, y=None):
         if self.transform is not None:
-            tout = self.transform(x)
-        else:
-            tout = x
+            x = self.transform(x)
 
         # TODO: return bout, hout for debugging, using a dict.
-        bout = self.backbone(tout)
+        bout = self.backbone(x)
 
         nout = self.neck(bout)
 


### PR DESCRIPTION
Thank you for your contribution to the MindOCR repo.
Before submitting this PR, please make sure:

- [x] You have read the [Contributing Guidelines on pull requests](https://github.com/mindspore-lab/mindcv/blob/main/CONTRIBUTING.md)
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved terminology
- [x] You have added unit tests

## Motivation
**Problem:**
ms.export interface loads the variable names in network to build the mindir files. Therefore, the change (`x` -> `tout`) of the input variable name of backbone will cause bugs while using convert_lite tool to convert mindir files for lite inference.

**Solution:**
Keep the input variable name of backbone as `x` to ensure backward compatibility. The models trained before can be converted to mindir files without additional modification on variable name mapping while using convert_lite tool.