### PR TITLE
fix det inference bug when empty

### DIFF
--- a/deploy/py_infer/src/infer/infer_det.py
+++ b/deploy/py_infer/src/infer/infer_det.py
@@ -55,5 +55,5 @@ class TextDetector(InferBase):
         polys = self.postprocess_ops(tuple(pred), shape_list)['polys'][0]  # {'polys': [img0_polys, ...], ...}
         polys = np.array(polys) if isinstance(polys, (tuple, list)) else polys
         # polys.shape may be (0,), (polys_num, points_num, 2), (1, polys_num, points_num, 2)
-        polys_shape = (-1, *polys.shape[-2:]) if len(polys.shape) != 1 else (0, 0, 2)
+        polys_shape = (-1, *polys.shape[-2:]) if polys.size != 0 else (0, 0, 2)
         return polys.reshape(*polys_shape)  # (polys_num, points_num, 2), because bs=1


### PR DESCRIPTION
Thank you for your contribution to the MindOCR repo.
Before submitting this PR, please make sure:

- [x] You have read the [Contributing Guidelines on pull requests](https://github.com/mindspore-lab/mindcv/blob/main/CONTRIBUTING.md)
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved terminology
- [ ] You have added unit tests

## Motivation

When the detection polys is empty, they may be multiple shape formats, so they need to be unified into the same shape.

## Test Plan

(How should this PR be tested? Do you require special setup to run the test or repro the fixed bug?)

## Related Issues and PRs

(Is this PR part of a group of changes? Link the other relevant PRs and Issues here. Use https://help.github.com/en/articles/closing-issues-using-keywords for help on GitHub syntax)
