### PR TITLE
Small fixes to post-processing pipeline

### DIFF
--- a/mindocr/data/builder.py
+++ b/mindocr/data/builder.py
@@ -9,27 +9,19 @@ from .rec_dataset import RecDataset
 from .rec_lmdb_dataset import LMDBDataset
 from .predict_dataset import PredictDataset
 
-__all__ = ["build_dataset"]
+__all__ = ['build_dataset']
 
-supported_dataset_types = [
-    "BaseDataset",
-    "DetDataset",
-    "RecDataset",
-    "LMDBDataset",
-    "SynthTextDataset",
-    "PredictDataset",
-]
-
+supported_dataset_types = ['BaseDataset', 'DetDataset', 'RecDataset', 'LMDBDataset', 'SynthTextDataset', 'PredictDataset']
 
 def build_dataset(
-    dataset_config: dict,
-    loader_config: dict,
-    num_shards=None,
-    shard_id=None,
-    is_train=True,
-    **kwargs,
-):
-    """
+        dataset_config: dict,
+        loader_config: dict,
+        num_shards=None,
+        shard_id=None,
+        is_train=True,
+        **kwargs,
+        ):
+    '''
     Build dataset for training and evaluation.
 
     Args:
@@ -89,7 +81,7 @@ def build_dataset(
         >>> }
         >>> loader_config = dict(shuffle=True, batch_size=16, drop_remainder=False, num_workers=1)
         >>> data_loader = build_dataset(data_config, loader_config, num_shards=1, shard_id=0, is_train=True)
-    """
+    '''
     # Check dataset paths (dataset_root, data_dir, and label_file) and update to absolute format
     dataset_config = _check_dataset_paths(dataset_config)
 
@@ -98,46 +90,42 @@ def build_dataset(
     num_devices = 1 if num_shards is None else num_shards
     cores = multiprocessing.cpu_count()
     NUM_WORKERS_BATCH = 2
-    NUM_WORKERS_MAP = int(
-        cores / num_devices - NUM_WORKERS_BATCH
-    )  # optimal num workers assuming all cpu cores are used in this job
+    NUM_WORKERS_MAP = int(cores / num_devices - NUM_WORKERS_BATCH) # optimal num workers assuming all cpu cores are used in this job
     num_workers = loader_config.get("num_workers", NUM_WORKERS_MAP)
     if num_workers > int(cores / num_devices):
-        print(
-            f"WARNING: `num_workers` is adjusted to {int(cores / num_devices)} since {num_workers}x{num_devices} exceeds the number of CPU cores {cores}"
-        )
+        print(f'WARNING: `num_workers` is adjusted to {int(cores / num_devices)} since {num_workers}x{num_devices} exceeds the number of CPU cores {cores}')
         num_workers = int(cores / num_devices)
     ## prefetch_size: the length of the cache queue in the data pipeline for each worker, used to reduce waiting time. Larger value leads to more memory consumption. Default: 16
-    prefetch_size = loader_config.get("prefetch_size", 16)  #
+    prefetch_size = loader_config.get("prefetch_size", 16) #
     ms.dataset.config.set_prefetch_size(prefetch_size)
     ## max_rowsize: MB of shared memory between processes to copy data. Only used when python_multiprocessing is True.
-    max_rowsize = loader_config.get("max_rowsize", 64)
+    max_rowsize =  loader_config.get("max_rowsize", 64)
     # auto tune num_workers, prefetch. (This conflicts the profiler)
-    # ms.dataset.config.set_autotune_interval(5)
-    # ms.dataset.config.set_enable_autotune(True, "./dataproc_autotune_out")
+    #ms.dataset.config.set_autotune_interval(5)
+    #ms.dataset.config.set_enable_autotune(True, "./dataproc_autotune_out")
 
     # 1. create source dataset (GeneratorDataset)
     ## Invoke dataset class
-    dataset_class_name = dataset_config.pop("type")
+    dataset_class_name = dataset_config.pop('type')
     assert dataset_class_name in supported_dataset_types, "Invalid dataset name"
     dataset_class = eval(dataset_class_name)
     dataset_args = dict(is_train=is_train, **dataset_config)
     dataset = dataset_class(**dataset_args)
 
     dataset_column_names = dataset.get_output_columns()
-    # print('=> Dataset output columns: \n\t', dataset_column_names)
+    #print('=> Dataset output columns: \n\t', dataset_column_names)
 
     ## Generate source dataset (source w.r.t. the dataset.map pipeline) based on python callable numpy dataset in parallel
     ds = ms.dataset.GeneratorDataset(
-        dataset,
-        column_names=dataset_column_names,
-        num_parallel_workers=num_workers,
-        num_shards=num_shards,
-        shard_id=shard_id,
-        python_multiprocessing=True,  # keep True to improve performace for heavy computation.
-        max_rowsize=max_rowsize,
-        shuffle=loader_config["shuffle"],
-    )
+                    dataset,
+                    column_names=dataset_column_names,
+                    num_parallel_workers=num_workers,
+                    num_shards=num_shards,
+                    shard_id=shard_id,
+                    python_multiprocessing=True, # keep True to improve performace for heavy computation.
+                    max_rowsize =max_rowsize,
+                    shuffle=loader_config['shuffle'],
+                    )
 
     # 2. data mapping using mindata C lib (optional)
     # ds = ds.map(operations=transform_list, input_columns=['image', 'label'], num_parallel_workers=8, python_multiprocessing=True)
@@ -145,71 +133,50 @@ def build_dataset(
     # 3. create loader
     # get batch of dataset by collecting batch_size consecutive data rows and apply batch operations
     num_samples = ds.get_dataset_size()
-    batch_size = loader_config["batch_size"]
+    batch_size = loader_config['batch_size']
 
     device_id = 0 if shard_id is None else shard_id
     is_main_device = device_id == 0
-    print(
-        f"INFO: Creating dataloader (training={is_train}) for device {device_id}. Number of data samples: {num_samples}"
-    )
+    print(f'INFO: Creating dataloader (training={is_train}) for device {device_id}. Number of data samples: {num_samples}')
 
-    if "refine_batch_size" in kwargs:
-        batch_size = _check_batch_size(
-            num_samples, batch_size, refine=kwargs["refine_batch_size"]
-        )
+    if 'refine_batch_size' in kwargs:
+        batch_size = _check_batch_size(num_samples, batch_size, refine=kwargs['refine_batch_size'])
 
-    drop_remainder = loader_config.get("drop_remainder", is_train)
+    drop_remainder = loader_config.get('drop_remainder', is_train)
     if is_train and drop_remainder == False and is_main_device:
-        print(
-            "WARNING: `drop_remainder` should be True for training, otherwise the last batch may lead to training fail in Graph mode"
-        )
+        print('WARNING: `drop_remainder` should be True for training, otherwise the last batch may lead to training fail in Graph mode')
 
     if not is_train:
         if drop_remainder and is_main_device:
-            print(
-                "WARNING: `drop_remainder` is forced to be False for evaluation to include the last batch for accurate evaluation."
-            )
+            print("WARNING: `drop_remainder` is forced to be False for evaluation to include the last batch for accurate evaluation." )
             drop_remainder = False
 
     dataloader = ds.batch(
-        batch_size,
-        drop_remainder=drop_remainder,
-        num_parallel_workers=min(
-            num_workers, 2
-        ),  # set small workers for lite computation. TODO: increase for batch-wise mapping
-        # input_columns=input_columns,
-        # output_columns=batch_column,
-        # per_batch_map=per_batch_map, # uncommet to use inner-batch transformation
-    )
+                    batch_size,
+                    drop_remainder=drop_remainder,
+                    num_parallel_workers=min(num_workers, 2), # set small workers for lite computation. TODO: increase for batch-wise mapping
+                    #input_columns=input_columns,
+                    #output_columns=batch_column,
+                    #per_batch_map=per_batch_map, # uncommet to use inner-batch transformation
+                    )
 
     return dataloader
 
 
 def _check_dataset_paths(dataset_config):
-    if "dataset_root" in dataset_config:
-        if isinstance(dataset_config["data_dir"], str):
-            dataset_config["data_dir"] = os.path.join(
-                dataset_config["dataset_root"], dataset_config["data_dir"]
-            )  # to absolute path
+    if 'dataset_root' in dataset_config:
+        if isinstance(dataset_config['data_dir'], str):
+            dataset_config['data_dir'] = os.path.join(dataset_config['dataset_root'], dataset_config['data_dir']) # to absolute path
         else:
-            dataset_config["data_dir"] = [
-                os.path.join(dataset_config["dataset_root"], dd)
-                for dd in dataset_config["data_dir"]
-            ]
-        if "label_file" in dataset_config:
-            if dataset_config["label_file"]:
-                if isinstance(dataset_config["label_file"], str):
-                    dataset_config["label_file"] = os.path.join(
-                        dataset_config["dataset_root"], dataset_config["label_file"]
-                    )
-                elif isinstance(dataset_config["label_file"], list):
-                    dataset_config["label_file"] = [
-                        os.path.join(dataset_config["dataset_root"], lf)
-                        for lf in dataset_config["label_file"]
-                    ]
+            dataset_config['data_dir'] = [os.path.join(dataset_config['dataset_root'], dd) for dd in dataset_config['data_dir']]
+        if 'label_file' in dataset_config:
+            if dataset_config['label_file']:
+                if isinstance(dataset_config['label_file'], str):
+                    dataset_config['label_file'] = os.path.join(dataset_config['dataset_root'], dataset_config['label_file'])
+                elif isinstance(dataset_config['label_file'], list):
+                    dataset_config['label_file'] = [os.path.join(dataset_config['dataset_root'], lf) for lf in dataset_config['label_file']]
 
     return dataset_config
-
 
 def _check_batch_size(num_samples, ori_batch_size=32, refine=True):
     if num_samples % ori_batch_size == 0:

--- a/mindocr/data/transforms/det_transforms.py
+++ b/mindocr/data/transforms/det_transforms.py
@@ -443,11 +443,10 @@ class DetResize(object):
         if 'polys' in data and self.is_train:
                 data['polys'][:, :, 0] = data['polys'][:, :, 0] * scale_w
                 data['polys'][:, :, 1] = data['polys'][:, :, 1] * scale_h
-                #print('transform GT polys to: ', data['polys'])
 
         if 'shape_list' not in data:
             src_h, src_w = data.get('raw_img_shape', (h, w))
-            data['shape_list'] = [src_h, src_w, scale_h, scale_w]
+            data['shape_list'] = np.array([src_h, src_w, scale_h, scale_w])
         else:
             data['shape_list'][2] = data['shape_list'][2] * scale_h
             data['shape_list'][3] = data['shape_list'][3] * scale_h

--- a/mindocr/data/transforms/det_transforms.py
+++ b/mindocr/data/transforms/det_transforms.py
@@ -12,10 +12,8 @@ import pyclipper
 from shapely.geometry import Polygon, box
 import numpy as np
 
-__all__ = ['DetLabelEncode', 'BorderMap', 'ShrinkBinaryMap', 'expand_poly', 'PSEGtDecode',
-           'ValidatePolygons', 'RandomCropWithBBox', 'RandomCropWithMask',
-           'DetResize', 'GridResize', 'ScalePadImage',
-           ]
+__all__ = ['DetLabelEncode', 'BorderMap', 'ShrinkBinaryMap', 'expand_poly', 'PSEGtDecode', 'ValidatePolygons',
+           'RandomCropWithBBox', 'RandomCropWithMask', 'DetResize', 'GridResize', 'ScalePadImage']
 
 
 class DetLabelEncode:
@@ -510,8 +508,8 @@ class PSEGtDecode(object):
             poly = Polygon(bbox)
             area, peri = poly.area, poly.length
 
-            offset = min((int)(area * (1 - rate) / (peri + 0.001) + 0.5), max_shr)
-            shrinked_bbox = expand_poly(bbox, -offset, pyclipper.JT_ROUND) # (N, 2) shape, N maybe larger than or smaller than 4.
+            offset = min(int(area * (1 - rate) / (peri + 0.001) + 0.5), max_shr)
+            shrinked_bbox = expand_poly(bbox, -offset)  # (N, 2) shape, N maybe larger than or smaller than 4.
             if not shrinked_bbox:
                 shrinked_text_polys.append(bbox)
                 continue
@@ -527,7 +525,6 @@ class PSEGtDecode(object):
         return shrinked_text_polys
 
     def __call__(self, data):
-
         image = data['image']
         text_polys = data['polys']
         ignore_tags = data['ignore_tags']
@@ -606,6 +603,7 @@ class ValidatePolygons:
                     poly = poly.exterior
                     poly = poly.coords[::-1] if poly.is_ccw else poly.coords    # sort in clockwise order
                     new_polys.append(np.array(poly[:-1]))
+
                 else:                                       # the polygon is fully outside the image
                     continue
             new_tags.append(ignore)
@@ -614,4 +612,5 @@ class ValidatePolygons:
         data['polys'] = new_polys
         data['texts'] = new_texts
         data['ignore_tags'] = np.array(new_tags)
+
         return data

--- a/mindocr/data/transforms/det_transforms.py
+++ b/mindocr/data/transforms/det_transforms.py
@@ -446,7 +446,7 @@ class DetResize(object):
 
         if 'shape_list' not in data:
             src_h, src_w = data.get('raw_img_shape', (h, w))
-            data['shape_list'] = np.array([src_h, src_w, scale_h, scale_w])
+            data['shape_list'] = np.array([src_h, src_w, scale_h, scale_w], dtype=np.float32)
         else:
             data['shape_list'][2] = data['shape_list'][2] * scale_h
             data['shape_list'][3] = data['shape_list'][3] * scale_h

--- a/mindocr/data/transforms/general_transforms.py
+++ b/mindocr/data/transforms/general_transforms.py
@@ -140,7 +140,7 @@ class RandomScale:
     def __init__(self, scale_range: Union[tuple, list], p: float = 0.5, **kwargs):
         self._range = scale_range
         self._p = p
-        self.is_train = kwargs.get('is_train', True)
+        assert kwargs.get('is_train', True), ValueError('RandomScale augmentation must be used for training only')
 
     def __call__(self, data: dict):
         """
@@ -155,10 +155,7 @@ class RandomScale:
             scale = np.random.uniform(*self._range)
             data['image'] = cv2.resize(data['image'], dsize=None, fx=scale, fy=scale)
             if 'polys' in data:
-                if self.is_train:
-                    data['polys'] *= scale
-                else:
-                    raise ValueError('Test time augmentation is not supported for detection currently. RandomScale should only be used for training.')
+                data['polys'] *= scale
 
         return data
 

--- a/mindocr/data/transforms/rec_transforms.py
+++ b/mindocr/data/transforms/rec_transforms.py
@@ -383,7 +383,7 @@ class RecResizeNormForInfer(object):
 
         # TODO: norm before padding
 
-        data['shape_list'] = np.array([h, w, resize_h / h, resize_w / w])   # TODO: reformat, currently align to det
+        data['shape_list'] = np.array([h, w, resize_h / h, resize_w / w], dtype=np.float32)    # TODO: reformat, currently align to det
         if self.norm_before_pad:
             resized_img = self.norm(resized_img) 
 

--- a/mindocr/data/transforms/rec_transforms.py
+++ b/mindocr/data/transforms/rec_transforms.py
@@ -383,7 +383,7 @@ class RecResizeNormForInfer(object):
 
         # TODO: norm before padding
 
-        data['shape_list'] = [h, w, resize_h / h, resize_w / w] # TODO: reformat, currently align to det
+        data['shape_list'] = np.array([h, w, resize_h / h, resize_w / w])   # TODO: reformat, currently align to det
         if self.norm_before_pad:
             resized_img = self.norm(resized_img) 
 

--- a/mindocr/postprocess/det_base_postprocess.py
+++ b/mindocr/postprocess/det_base_postprocess.py
@@ -87,18 +87,13 @@ class DetBasePostprocess:
         polygons (Union[List[np.ndarray], np.ndarray]): polygons for an image, shape [num_polygons, num_points, 2], value: xy coordinates for all polygon points
         shape_list (np.ndarray): shape and scale info for the image, shape [4,], value: [src_h, src_w, scale_h, scale_w]
         """
-        scale_w_h = shape_list[:1:-1]
-        src_h, src_w = shape_list[0], shape_list[1]
+        scale = shape_list[:1:-1]
+        size = shape_list[1::-1] - 1
 
         if isinstance(polygons, np.ndarray):
-            polygons = np.round(polygons / scale_w_h)
-            polygons[..., 0] = np.clip(polygons[..., 0], 0, src_w - 1)
-            polygons[..., 1] = np.clip(polygons[..., 1], 0, src_h - 1)
-        else:
-            polygons = [np.round(poly / scale_w_h) for poly in polygons]
-            for i, poly in enumerate(polygons):
-                polygons[i][:, 0] = np.clip(poly[:, 0], 0, src_w - 1)
-                polygons[i][:, 1] = np.clip(poly[:, 1], 0, src_h - 1)
+            polygons = np.clip(np.round(polygons / scale), 0, size)
+        else:   # if polygons have different number of vertices and stored as a list
+            polygons = [np.clip(np.round(poly / scale), 0, size) for poly in polygons]
 
         return polygons
 

--- a/mindocr/postprocess/det_base_postprocess.py
+++ b/mindocr/postprocess/det_base_postprocess.py
@@ -1,14 +1,9 @@
 from typing import Tuple, Union, List, Dict
-import cv2
 import numpy as np
 import mindspore as ms
 from mindspore import Tensor
-from mindspore import nn
-from shapely.geometry import Polygon
 
-from ..data.transforms.det_transforms import expand_poly
-
-__all__ = ["DBBasePostprocess"]
+__all__ = ["DetBasePostprocess"]
 
 
 class DetBasePostprocess:
@@ -19,22 +14,16 @@ class DetBasePostprocess:
         box_type (str): text region representation type after postprocessing, options: ['quad', 'poly']
         rescale_fields (list): names of fields to rescale back to the shape of the original image.
     """
-
     def __init__(self, box_type="quad", rescale_fields: List[str] = ["polys"]):
-        assert box_type in ["quad", "poly",], f"box_type must be `quad` or `poly`, but found {box_type}"
+        assert box_type in ["quad", "poly"], f"box_type must be `quad` or `poly`, but found {box_type}"
 
         self._rescale_fields = rescale_fields
         self.warned = False
         if self._rescale_fields is None:
-            print(
-                "WARNING: `rescale_filed` is None. Cannot rescale the predicted polygons to original image space"
-            )
+            print("WARNING: `rescale_filed` is None. Cannot rescale the predicted polygons to original image space")
 
-
-    def _postprocess(
-        self, pred: Union[ms.Tensor, Tuple[ms.Tensor], np.ndarray], **kwargs
-    ) -> dict:
-        '''
+    def _postprocess(self, pred: Union[ms.Tensor, Tuple[ms.Tensor], np.ndarray], **kwargs) -> dict:
+        """
         Postprocess network prediction to get text boxes on the transformed image space (which will be rescaled back to original image space in __call__ function)
 
         Args:
@@ -48,16 +37,11 @@ class DetBasePostprocess:
         Notes:
             - Please cast `pred` to the type you need in your implementation. Some postprocesssing steps use ops from mindspore.nn and prefer Tensor type, while some steps prefer np.ndarray type required in other libraries.
             - `_postprocess()` should **NOT round** the text box `polys` to integer in return, because they will be recaled and then rounded in the end. Rounding early will cause larger error in polygon rescaling and results in **evaluation performance degradation**, especially on small datasets.
-        '''
+        """
         raise NotImplementedError
 
-
-    def __call__(
-        self,
-        pred: Union[ms.Tensor, Tuple[ms.Tensor], np.ndarray],
-        shape_list: Union[List, np.ndarray, ms.Tensor] = None,
-        **kwargs,
-    ) -> dict:
+    def __call__(self, pred: Union[ms.Tensor, Tuple[ms.Tensor], np.ndarray],
+                 shape_list: Union[List, np.ndarray, ms.Tensor] = None, **kwargs) -> dict:
         """
         Execution entry for postprocessing, which postprocess network prediction on the transformed image space to get text boxes and then rescale them back to the original image space.
 
@@ -78,16 +62,16 @@ class DetBasePostprocess:
             shape_list = np.array(shape_list, dtype="float32")
 
         if shape_list is not None:
-            assert (
-                len(shape_list) > 0 and len(shape_list[0]) == 4
-            ), f"The length of each element in shape_list must be 4 for [raw_img_h, raw_img_w, scale_h, scale_w]. But get shape list {shape_list}"
+            assert shape_list.shape[0] == pred.shape[0] and shape_list.shape[1] == 4, \
+                f"The length of each element in shape_list must be 4 for [raw_img_h, raw_img_w, scale_h, scale_w]. But get shape list {shape_list}"
         else:
             # shape_list = [[pred.shape[2], pred.shape[3], 1.0, 1.0] for i in range(pred.shape[0])] # H, W
             # shape_list = np.array(shape_list, dtype='float32')
 
-            print(
-                "WARNING: `shape_list` is None in postprocessing. Cannot rescale the prediction result to original image space, which can lead to inaccraute evaluatoin. You may add `shape_list` to `output_columns` list under eval section in yaml config file, or directly parse `shape_list` to postprocess callable function."
-            )
+            print("WARNING: `shape_list` is None in postprocessing. Cannot rescale the prediction result to original "
+                  "image space, which can lead to inaccurate evaluation. You may add `shape_list` to `output_columns` "
+                  "list under eval section in yaml config file, or directly parse `shape_list` to postprocess callable "
+                  "function.")
             self.warned = True
 
         # 2. Core process
@@ -99,7 +83,6 @@ class DetBasePostprocess:
 
         return result
 
-
     @staticmethod
     def _rescale_polygons(polygons: Union[List[np.ndarray], np.ndarray], shape_list: np.ndarray):
         """
@@ -109,24 +92,21 @@ class DetBasePostprocess:
         scale_w_h = shape_list[:1:-1]
         src_h, src_w = shape_list[0], shape_list[1]
 
-        #print('DEBUG: before rescale, poly 0: ', polygons[0], 'shape list: ', shape_list[0])
         if isinstance(polygons, np.ndarray):
             polygons = np.round(polygons / scale_w_h)
-            polygons[...,0] = np.clip(polygons[..., 0], 0, src_w - 1)
-            polygons[...,1] = np.clip(polygons[..., 1], 0, src_h - 1)
+            polygons[..., 0] = np.clip(polygons[..., 0], 0, src_w - 1)
+            polygons[..., 1] = np.clip(polygons[..., 1], 0, src_h - 1)
         else:
             polygons = [np.round(poly / scale_w_h) for poly in polygons]
             for i, poly in enumerate(polygons):
-                polygons[i][:,0] = np.clip(poly[:, 0], 0, src_w - 1)
-                polygons[i][:,1] = np.clip(poly[:, 1], 0, src_h - 1)
-
-        #print('DEBUG: After rescale, poly 0: ', polygons[0])
+                polygons[i][:, 0] = np.clip(poly[:, 0], 0, src_w - 1)
+                polygons[i][:, 1] = np.clip(poly[:, 1], 0, src_h - 1)
 
         return polygons
 
     def rescale(self, result: Dict, shape_list: np.ndarray) -> dict:
         """
-        rescale result back to orginal image shape
+        rescale result back to original image shape
 
         Args:
             result (dict) with keys for the input data batch
@@ -138,12 +118,11 @@ class DetBasePostprocess:
         """
 
         for field in self._rescale_fields:
-            assert (
-                field in result
-            ), f"Invalid field {field}. Found fields in intermidate postprocess result are {list(result.keys())}"
+            assert (field in result), \
+                f"Invalid field {field}. Found fields in intermediate postprocess result are {list(result.keys())}"
+
             for i, sample in enumerate(result[field]):
                 if len(sample) > 0:
                     result[field][i] = self._rescale_polygons(sample, shape_list[i])
 
         return result
-

--- a/mindocr/postprocess/det_base_postprocess.py
+++ b/mindocr/postprocess/det_base_postprocess.py
@@ -41,13 +41,13 @@ class DetBasePostprocess:
         raise NotImplementedError
 
     def __call__(self, pred: Union[ms.Tensor, Tuple[ms.Tensor], np.ndarray],
-                 shape_list: Union[List, np.ndarray, ms.Tensor] = None, **kwargs) -> dict:
+                 shape_list: Union[np.ndarray, ms.Tensor] = None, **kwargs) -> dict:
         """
         Execution entry for postprocessing, which postprocess network prediction on the transformed image space to get text boxes and then rescale them back to the original image space.
 
         Args:
             pred (Union[Tensor, Tuple[Tensor], np.ndarray]): network prediction for input batch data, shape [batch_size, ...]
-            shape_list (Union[List, np.ndarray, ms.Tensor]): shape and scale info for each image in the batch, shape [batch_size, 4]. Each internal array is [src_h, src_w, scale_h, scale_w], where src_h and src_w are height and width of the original image, and scale_h and scale_w are their scale ratio during image resizing.
+            shape_list (Union[np.ndarray, ms.Tensor]): shape and scale info for each image in the batch, shape [batch_size, 4]. Each internal array is [src_h, src_w, scale_h, scale_w], where src_h and src_w are height and width of the original image, and scale_h and scale_w are their scale ratio during image resizing.
 
         Returns:
             detection result as a dict with keys:
@@ -58,8 +58,6 @@ class DetBasePostprocess:
         # 1. Check input type. Covert shape_list to np.ndarray
         if isinstance(shape_list, Tensor):
             shape_list = shape_list.asnumpy()
-        elif isinstance(shape_list, List):
-            shape_list = np.array(shape_list, dtype="float32")
 
         if shape_list is not None:
             assert shape_list.shape[0] == pred.shape[0] and shape_list.shape[1] == 4, \

--- a/mindocr/postprocess/det_db_postprocess.py
+++ b/mindocr/postprocess/det_db_postprocess.py
@@ -1,9 +1,8 @@
 from typing import Tuple, Union, List
+
 import cv2
 import numpy as np
-import mindspore as ms
 from mindspore import Tensor
-from mindspore import nn
 from shapely.geometry import Polygon
 
 from .det_base_postprocess import DetBasePostprocess
@@ -22,20 +21,20 @@ class DBPostprocess(DetBasePostprocess):
         max_candidates: maximum number of proposed polygons.
         expand_ratio: controls by how much polygons need to be expanded to recover the original text shape
             (DBNet predicts shrunken text masks).
-        output_polygon: output polygons or rectangles as the network's predictions.
+        box_type: output polygons ('polys') or rectangles ('quad') as the network's predictions.
         pred_name: heatmap's name used for polygons extraction.
         rescale_fields: name of fields to scale back to the shape of the original image.
     """
 
     def __init__(
-        self,
-        binary_thresh: float = 0.3,
-        box_thresh: float = 0.7,
-        max_candidates: int = 1000,
-        expand_ratio: float = 1.5,
-        box_type="quad",
-        pred_name: str = "binary",
-        rescale_fields: List[str] = ["polys"],
+            self,
+            binary_thresh: float = 0.3,
+            box_thresh: float = 0.7,
+            max_candidates: int = 1000,
+            expand_ratio: float = 1.5,
+            box_type="quad",
+            pred_name: str = "binary",
+            rescale_fields: List[str] = ["polys"]
     ):
         super().__init__(box_type, rescale_fields)
 
@@ -48,21 +47,21 @@ class DBPostprocess(DetBasePostprocess):
         self._name = pred_name
         self._names = {"binary": 0, "thresh": 1, "thresh_binary": 2}
 
-    def _postprocess(
-        self, pred: Union[Tensor, Tuple[Tensor], np.ndarray], **kwargs
-    ) -> dict:
+    def _postprocess(self, pred: Union[Tensor, Tuple[Tensor], np.ndarray], **kwargs) -> dict:
         """
-        Postprocess network prediction to get text boxes on the transformed image space (which will be rescaled back to original image space in __call__ function)
+        Postprocess network prediction to get text boxes on the transformed image space (which will be rescaled back to
+        original image space in __call__ function)
 
         Args:
-			pred (Union[Tensor, Tuple[Tensor], np.ndarray]): network prediction consists of
-				binary: text region segmentation map, with shape (N, 1, H, W)
-				thresh: [if exists] threshold prediction with shape (N, 1, H, W) (optional)
-				thresh_binary: [if exists] binarized with threshold, (N, 1, H, W) (optional)
+            pred (Union[Tensor, Tuple[Tensor], np.ndarray]): network prediction consists of
+                binary: text region segmentation map, with shape (N, 1, H, W)
+                thresh: [if exists] threshold prediction with shape (N, 1, H, W) (optional)
+                thresh_binary: [if exists] binarized with threshold, (N, 1, H, W) (optional)
 
-		Return:
+        Returns:
             postprocessing result as a dict with keys:
-                - polys (List[List[np.ndarray]): predicted polygons on the **transformed** (i.e. resized normally) image space, of shape (batch_size, num_polygons, num_points, 2). If `box_type` is 'quad', num_points=4.
+                - polys (List[np.ndarray]): predicted polygons on the **transformed** (i.e. resized normally) image
+                space, of shape (batch_size, num_polygons, num_points, 2). If `box_type` is 'quad', num_points=4.
                 - scores (np.ndarray): confidence scores for the predicted polygons, shape (batch_size, num_polygons)
         """
         if isinstance(pred, tuple):
@@ -73,31 +72,23 @@ class DBPostprocess(DetBasePostprocess):
 
         segmentation = pred >= self._binary_thresh
 
-        dest_size = np.array(pred.shape[:0:-1]) - 1
-
         polys, scores = [], []
-        for pr, segm, size in zip(pred, segmentation, dest_size):
-            sample_polys, sample_scores = self._extract_preds(pr, segm, size)
+        for pr, segm in zip(pred, segmentation):
+            sample_polys, sample_scores = self._extract_preds(pr, segm)
             polys.append(sample_polys)
             scores.append(sample_scores)
 
-        output = {"polys": polys, "scores": scores}
+        return {"polys": polys, "scores": scores}
 
-        return output
-
-    def _extract_preds(
-        self, pred: np.ndarray, bitmap: np.ndarray, dest_size: np.ndarray
-    ):
-        outs = cv2.findContours(
-            bitmap.astype(np.uint8), cv2.RETR_LIST, cv2.CHAIN_APPROX_SIMPLE
-        )
+    def _extract_preds(self, pred: np.ndarray, bitmap: np.ndarray):
+        outs = cv2.findContours(bitmap.astype(np.uint8), cv2.RETR_LIST, cv2.CHAIN_APPROX_SIMPLE)
         if len(outs) == 3:  # FIXME: update to OpenCV 4.x and delete this
             _, contours, _ = outs[0], outs[1], outs[2]
         elif len(outs) == 2:
             contours, _ = outs[0], outs[1]
 
         polys, scores = [], []
-        for contour in contours[: self._max_candidates]:
+        for contour in contours[:self._max_candidates]:
             contour = contour.squeeze(1)
             score = self._calc_score(pred, bitmap, contour)
             if score < self._box_thresh:
@@ -114,11 +105,7 @@ class DBPostprocess(DetBasePostprocess):
                     continue
 
             poly = Polygon(points)
-            poly = np.array(
-                expand_poly(
-                    points, distance=poly.area * self._expand_ratio / poly.length
-                )
-            )
+            poly = np.array(expand_poly(points, distance=poly.area * self._expand_ratio / poly.length))
             if self._out_poly and len(poly) > 1:
                 continue
             poly = poly.reshape(-1, 2)
@@ -134,7 +121,7 @@ class DBPostprocess(DetBasePostprocess):
             # box = np.array(expand_poly(points, distance=box.area * self._expand_ratio / box.length, joint_type=pyclipper.JT_MITER))
             # assert box.shape[0] == 4, print(f'box shape is {box.shape}')
 
-            polys.append(np.clip(poly, 0, dest_size).astype(np.float32)) # keep float before rescaling
+            polys.append(poly)
             scores.append(score)
 
         if self._out_poly:
@@ -177,19 +164,8 @@ class DBPostprocess(DetBasePostprocess):
 
     @staticmethod
     def _calc_score(pred, mask, contour):
-        """
-        calculates score (mean value) of a prediction inside a given contour.
-        """
-        min_vals = np.clip(
-            np.floor(np.min(contour, axis=0)), 0, np.array(pred.shape[::-1]) - 1
-        ).astype(np.int32)
-        max_vals = np.clip(
-            np.ceil(np.max(contour, axis=0)), 0, np.array(pred.shape[::-1]) - 1
-        ).astype(np.int32)
-
-        return cv2.mean(
-            pred[min_vals[1] : max_vals[1] + 1, min_vals[0] : max_vals[0] + 1],
-            mask[min_vals[1] : max_vals[1] + 1, min_vals[0] : max_vals[0] + 1].astype(
-                np.uint8
-            ),
-        )[0]
+        # calculates score (mean value) of a prediction inside a given contour.
+        min_vals = np.clip(np.floor(np.min(contour, axis=0)), 0, np.array(pred.shape[::-1]) - 1).astype(np.int32)
+        max_vals = np.clip(np.ceil(np.max(contour, axis=0)), 0, np.array(pred.shape[::-1]) - 1).astype(np.int32)
+        return cv2.mean(pred[min_vals[1]:max_vals[1] + 1, min_vals[0]:max_vals[0] + 1],
+                        mask[min_vals[1]:max_vals[1] + 1, min_vals[0]:max_vals[0] + 1].astype(np.uint8))[0]

--- a/mindocr/postprocess/det_east_postprocess.py
+++ b/mindocr/postprocess/det_east_postprocess.py
@@ -24,7 +24,6 @@ class EASTPostprocess(DetBasePostprocess):
                 pred (tuple) - (score, geo)
                     'score'       : score map from model <Tensor, (bs,1,row,col)>
                     'geo'         : geo map from model <Tensor, (bs,5,row,col)>
-                shape_list (List[List[float]]: a list of shape info [raw_img_h, raw_img_w, ratio_h, ratio_w] for each sample in batch
         Output:
                 boxes       : dict of polys and scores {'polys': <numpy.ndarray, (bs,n,4,2)>, 'scores': numpy.ndarray, (bs,n,1)>)}
         """


### PR DESCRIPTION
Thank you for your contribution to the MindOCR repo.
Before submitting this PR, please make sure:

- [x] You have read the [Contributing Guidelines on pull requests](https://github.com/mindspore-lab/mindcv/blob/main/CONTRIBUTING.md)
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved terminology
- [ ] You have added unit tests

## Motivation

- Fixed bug that caused evaluation crash if no postprocessing is set.
- Fixed `DetBasePostprocess` class import from outside and refactored it.
- Moved training condition check to initialization in `RandomScale` as this condition needs to be checked once only.
- Reverted linting in `mindocr/data/builder.py` to avoid complicated merge conflicts with the new pipeline (#300).
- Set `shape_list` as numpy array throughout the project.
- Removed polygons clipping in `DBPostprocess` to keep all the clippings in one place (`DetBasePostprocess`).