### PR TITLE
Add SVTR Chinese.benchmark model and Update CRNN benchmark model, and others

### DIFF
--- a/configs/rec/crnn/README.md
+++ b/configs/rec/crnn/README.md
@@ -367,7 +367,7 @@ For detailed instruction of data preparation and yaml configuration, please refe
 To train with the prepared datsets and config file, please run:
 
 ```shell
-mpirun --allow-run-as-root -n 8 python tools/train.py --config configs/rec/crnn/crnn_resnet34_ch.yaml
+mpirun --allow-run-as-root -n 4 python tools/train.py --config configs/rec/crnn/crnn_resnet34_ch.yaml
 ```
 
 ### Results and Pretrained Weights
@@ -376,9 +376,9 @@ After training, evaluation results on the benchmark test set are as follows, whe
 
 <div align="center">
 
-| **Model** | **Language** | **Backbone** | **Scene** | **Web** | **Document** | **Recipe** | **Download** | 
-| :-----: | :-----:  | :--------: | :--------: | :--------: | :--------: | :---------: | :-----------: |
-| CRNN    | Chinese | ResNet34_vd | 59.71% | 64.86% | 89.23% |  [crnn_resnet34_ch.yaml](https://github.com/mindspore-lab/mindocr/blob/main/configs/rec/crnn/crnn_resnet34_ch.yaml) | [ckpt](https://download.mindspore.cn/toolkits/mindocr/crnn/crnn_resnet34_ch-a8d0f5d3.ckpt) \| [mindir](https://download.mindspore.cn/toolkits/mindocr/crnn/crnn_resnet34_ch-a8d0f5d3-f27f763a.mindir) |
+| **Model** | **Language** | **Context**  |**Backbone** | **Scene** | **Web** | **Document** | **Train T.** | **FPS** | **Recipe** | **Download** | 
+| :-----: | :-----:  | :--------: | :--------: | :--------: | :--------: | :--------: | :---------: | :--------: | :---------: | :-----------: |
+| CRNN    | Chinese | D910x4-MS1.10-G | ResNet34_vd | 60.45% | 65.95% | 97.68% | 647 s/epoch | 1180 | [crnn_resnet34_ch.yaml](https://github.com/mindspore-lab/mindocr/blob/main/configs/rec/crnn/crnn_resnet34_ch.yaml) | [ckpt](https://download.mindspore.cn/toolkits/mindocr/crnn/crnn_resnet34_ch-7a342e3c.ckpt) \| [mindir]() |
 </div>
 
 ### Training with Custom Datasets

--- a/configs/rec/crnn/README_CN.md
+++ b/configs/rec/crnn/README_CN.md
@@ -369,7 +369,7 @@ Mindocr内置了一部分字典，均放在了 `mindocr/utils/dict/` 位置，�
 准备好数据集和配置文件后，执行以下命令开启多卡训练
 
 ```shell
-mpirun --allow-run-as-root -n 8 python tools/train.py --config configs/rec/crnn/crnn_resnet34_ch.yaml
+mpirun --allow-run-as-root -n 4 python tools/train.py --config configs/rec/crnn/crnn_resnet34_ch.yaml
 ```
 
 ### 评估结果和预训练权重
@@ -377,9 +377,9 @@ mpirun --allow-run-as-root -n 8 python tools/train.py --config configs/rec/crnn/
 
 <div align="center">
 
-| **模型** | **语种** | **骨干网络** | **街景类** | **网页类** | **文档类** | **配置文件** | **模型权重下载** | 
-| :-----: | :-----:  | :--------: | :--------: | :--------: | :--------: | :---------: | :-----------: |
-| CRNN    | 中文 | ResNet34_vd | 59.71% | 64.86% | 89.23% |  [crnn_resnet34_ch.yaml](https://github.com/mindspore-lab/mindocr/blob/main/configs/rec/crnn/crnn_resnet34_ch.yaml) | [ckpt](https://download.mindspore.cn/toolkits/mindocr/crnn/crnn_resnet34_ch-a8d0f5d3.ckpt) \| [mindir](https://download.mindspore.cn/toolkits/mindocr/crnn/crnn_resnet34_ch-a8d0f5d3-f27f763a.mindir) |
+| **模型** | **语种** | **环境配置** | **骨干网络** | **街景类** | **网页类** | **文档类** | **训练时间** | **FPS** | **配置文件** | **模型权重下载** | 
+| :-----: | :-----:  | :-------:  |:--------: | :--------: | :--------: | :--------: | :---------: |:--------: | :---------: | :-----------: |
+| CRNN    | 中文 | D910x4-MS1.10-G | ResNet34_vd | 60.45% | 65.95% | 97.68% | 647 s/epoch | 1180 | [crnn_resnet34_ch.yaml](https://github.com/mindspore-lab/mindocr/blob/main/configs/rec/crnn/crnn_resnet34_ch.yaml) | [ckpt](https://download.mindspore.cn/toolkits/mindocr/crnn/crnn_resnet34_ch-7a342e3c.ckpt) \| [mindir]() |
 </div>
 
 ### 使用自定义数据集进行训练

--- a/configs/rec/crnn/crnn_resnet34_ch.yaml
+++ b/configs/rec/crnn/crnn_resnet34_ch.yaml
@@ -1,19 +1,20 @@
 system:
   mode: 0 # 0 for graph mode, 1 for pynative mode in MindSpore
   distribute: True
-  amp_level: 'O3'
+  amp_level: O2
   seed: 42
   log_interval: 100
   val_while_train: True
   drop_overflow_update: False
+  ckpt_max_keep: 5
 
 common:
-  character_dict_path: &character_dict_path  mindocr/utils/dict/ch_dict.txt
-  num_classes: &num_classes 6624 # num_chars_in_dict+1,  TODO: retreive it from dict or check correctness
-  max_text_len: &max_text_len 24
+  character_dict_path: &character_dict_path mindocr/utils/dict/ch_dict.txt
+  num_classes: &num_classes 6624 # num_chars_in_dict + 1
+  max_text_len: &max_text_len 40
   infer_mode: &infer_mode False
   use_space_char: &use_space_char False
-  batch_size: &batch_size 64
+  batch_size: &batch_size 256
 
 model:
   type: rec
@@ -23,18 +24,16 @@ model:
     pretrained: False
   neck:
     name: RNNEncoder
-    hidden_size: 256 
+    hidden_size: 64
   head:
-    name: CTCHead 
-    weight_init: crnn_customised
-    bias_init: crnn_customised
-    out_channels: *num_classes 
+    name: CTCHead
+    out_channels: *num_classes
 
 postprocess:
   name: RecCTCLabelDecode
   character_dict_path: *character_dict_path
   use_space_char: *use_space_char
- 
+
 metric:
   name: RecMetric
   main_indicator: acc
@@ -43,14 +42,14 @@ metric:
   print_flag: False
 
 loss:
-  name: CTCLoss 
-  pred_seq_len: 25 # TODO: retrieve from the network output shape.
-  max_label_len: *max_text_len  # this value should be smaller than pre_seq_len
+  name: CTCLoss
+  pred_seq_len: 80 # 320 / 4
+  max_label_len: *max_text_len # this value should be smaller than pre_seq_len
   batch_size: *batch_size
 
-scheduler: 
+scheduler:
   scheduler: warmup_cosine_decay
-  min_lr: 0.0
+  min_lr: 0.00001
   lr: 0.001
   num_epochs: 60
   warmup_epochs: 6
@@ -59,60 +58,60 @@ scheduler:
 optimizer:
   opt: adamw
   filter_bias_and_bn: True
-  momentum: 0.95
-  weight_decay: 0.0001
-  nesterov: False
-  #use_nesterov: True 
+  weight_decay: 0.05
 
 loss_scaler:
-  type: static
+  type: dynamic
   loss_scale: 512
+  scale_factor: 2.0
+  scale_window: 1000
 
 train:
-  ema: True
-  ema_decay: 0.9999
-  ckpt_save_dir: './tmp_rec'
+  ckpt_save_dir: ./tmp_rec
   dataset_sink_mode: False
-  pred_cast_fp32: False
+  clip_grad: True
+  clip_norm: 0.1
   dataset:
     type: LMDBDataset
-    dataset_root: path/to/chinese_text_recognition/ # Optional, if set, dataset_root will be used as a prefix for data_dir
+    dataset_root: path/to/chinese_text_recognition/
     data_dir: training/
-    # label_file: # not required when using LMDBDataset
     sample_ratio: 1.0
     shuffle: True
+    filter_max_len: True
+    max_text_len: *max_text_len
     transform_pipeline:
-      - DecodeImage: 
+      - DecodeImage:
           img_mode: BGR
           to_float32: False
       - RecCTCLabelEncode:
-          max_text_len: *max_text_len 
+          max_text_len: *max_text_len
           character_dict_path: *character_dict_path
           use_space_char: *use_space_char
-          lower: False
-      - RecResizeImg: # different from paddle (paddle converts image from HWC to CHW and rescale to [-1, 1] after resize. 
-          image_shape: [32, 100] # H, W
+          lower: True
+      - Rotate90IfVertical:
+          threshold: 2.0
+          direction: anti_clockwise
+      - RecResizeImg:
+          image_shape: [32, 320]
           infer_mode: *infer_mode
           character_dict_path: *character_dict_path
-          padding: False # aspect ratio will be preserved if true.
-      - NormalizeImage:  # different from paddle (paddle wrongly normalize BGR image with RGB mean/std from ImageNet for det, and simple rescale to [-1, 1] in rec. 
+          padding: True
+      - NormalizeImage:
           bgr_to_rgb: True
           is_hwc: True
-          mean : [127.0, 127.0, 127.0] 
-          std : [127.0, 127.0, 127.0]
-      - ToCHWImage: 
-    #  the order of the dataloader list, matching the network input and the input labels for the loss function, and optional data for debug/visaulize 
-    output_columns: ['image', 'text_seq'] #, 'length'] #'img_path'] 
-    net_input_column_index: [0] # input indices for network forward func in output_columns
-    label_column_index: [1] # input indices marked as label
-    #keys_for_loss: 4 # num labels for loss func 
-     
+          mean: [127.0, 127.0, 127.0]
+          std: [127.0, 127.0, 127.0]
+      - ToCHWImage:
+    output_columns: ["image", "text_seq"]
+    net_input_column_index: [0]
+    label_column_index: [1]
+
   loader:
-      shuffle: True # TODO: tbc
-      batch_size: *batch_size
-      drop_remainder: True
-      max_rowsize: 12
-      num_workers: 8
+    shuffle: True
+    batch_size: *batch_size
+    drop_remainder: True
+    max_rowsize: 12
+    num_workers: 1
 
 eval:
   ckpt_load_path: ./tmp_rec/best.ckpt
@@ -121,37 +120,38 @@ eval:
     type: LMDBDataset
     dataset_root: path/to/chinese_text_recognition/
     data_dir: validation/
-    # label_file: # not required when using LMDBDataset
     sample_ratio: 1.0
-    shuffle: False 
+    shuffle: False
     transform_pipeline:
-      - DecodeImage: 
+      - DecodeImage:
           img_mode: BGR
           to_float32: False
       - RecCTCLabelEncode:
-          max_text_len: *max_text_len 
+          max_text_len: *max_text_len
           character_dict_path: *character_dict_path
           use_space_char: *use_space_char
-          lower: False
-      - RecResizeImg: # different from paddle (paddle converts image from HWC to CHW and rescale to [-1, 1] after resize. 
-          image_shape: [32, 100] # H, W
+          lower: True
+      - Rotate90IfVertical:
+          threshold: 2.0
+          direction: anti_clockwise
+      - RecResizeImg:
+          image_shape: [32, 320]
           infer_mode: *infer_mode
           character_dict_path: *character_dict_path
-          padding: False # aspect ratio will be preserved if true.
-      - NormalizeImage:  # different from paddle (paddle wrongly normalize BGR image with RGB mean/std from ImageNet for det, and simple rescale to [-1, 1] in rec. 
+          padding: True
+      - NormalizeImage:
           bgr_to_rgb: True
           is_hwc: True
-          mean : [127.0, 127.0, 127.0] 
-          std : [127.0, 127.0, 127.0]
-      - ToCHWImage: 
-    #  the order of the dataloader list, matching the network input and the input labels for the loss function, and optional data for debug/visaulize 
-    output_columns: ['image', 'text_padded', 'text_length']  # TODO return text string padding w/ fixed length, and a scaler to indicate the length 
-    net_input_column_index: [0] # input indices for network forward func in output_columns
-    label_column_index: [1, 2] # input indices marked as label
-     
+          mean: [127.0, 127.0, 127.0]
+          std: [127.0, 127.0, 127.0]
+      - ToCHWImage:
+    output_columns: ["image", "text_padded", "text_length"]
+    net_input_column_index: [0]
+    label_column_index: [1, 2]
+
   loader:
-      shuffle: False # TODO: tbc
-      batch_size: 64
-      drop_remainder: False
-      max_rowsize: 12
-      num_workers: 8
+    shuffle: False
+    batch_size: 64
+    drop_remainder: False
+    max_rowsize: 12
+    num_workers: 1

--- a/configs/rec/crnn/crnn_resnet34_ch.yaml
+++ b/configs/rec/crnn/crnn_resnet34_ch.yaml
@@ -93,7 +93,7 @@ train:
           lower: False
       - Rotate90IfVertical:
           threshold: 2.0
-          direction: anti_clockwise
+          direction: counterclockwise
       - RecResizeImg:
           image_shape: [32, 320]
           infer_mode: *infer_mode
@@ -137,7 +137,7 @@ eval:
           lower: False
       - Rotate90IfVertical:
           threshold: 2.0
-          direction: anti_clockwise
+          direction: counterclockwise
       - RecResizeImg:
           image_shape: [32, 320]
           infer_mode: *infer_mode

--- a/configs/rec/crnn/crnn_resnet34_ch.yaml
+++ b/configs/rec/crnn/crnn_resnet34_ch.yaml
@@ -37,6 +37,7 @@ postprocess:
 metric:
   name: RecMetric
   main_indicator: acc
+  lower: False
   character_dict_path: *character_dict_path
   ignore_space: True
   print_flag: False
@@ -75,6 +76,7 @@ train:
     type: LMDBDataset
     dataset_root: path/to/chinese_text_recognition/
     data_dir: training/
+    label_file: null
     sample_ratio: 1.0
     shuffle: True
     filter_max_len: True
@@ -87,7 +89,7 @@ train:
           max_text_len: *max_text_len
           character_dict_path: *character_dict_path
           use_space_char: *use_space_char
-          lower: True
+          lower: False
       - Rotate90IfVertical:
           threshold: 2.0
           direction: anti_clockwise
@@ -120,6 +122,7 @@ eval:
     type: LMDBDataset
     dataset_root: path/to/chinese_text_recognition/
     data_dir: validation/
+    label_file: null
     sample_ratio: 1.0
     shuffle: False
     transform_pipeline:
@@ -130,7 +133,7 @@ eval:
           max_text_len: *max_text_len
           character_dict_path: *character_dict_path
           use_space_char: *use_space_char
-          lower: True
+          lower: False
       - Rotate90IfVertical:
           threshold: 2.0
           direction: anti_clockwise

--- a/configs/rec/crnn/crnn_resnet34_ch.yaml
+++ b/configs/rec/crnn/crnn_resnet34_ch.yaml
@@ -2,6 +2,7 @@ system:
   mode: 0 # 0 for graph mode, 1 for pynative mode in MindSpore
   distribute: True
   amp_level: O2
+  amp_level_infer: O2 # running inference in O2 mode
   seed: 42
   log_interval: 100
   val_while_train: True

--- a/configs/rec/rare/README.md
+++ b/configs/rec/rare/README.md
@@ -350,7 +350,7 @@ After training, evaluation results on the benchmark test set are as follows, whe
 
 | **Model** | **Language** | **Backbone** | **Transform Module** | **Scene** | **Web** | **Document** | **Train T.** | **FPS** | **Recipe** | **Download** | 
 | :-----: | :-----:  | :--------: | :------------: | :--------: | :--------: | :--------: | :--------: | :--------: |:---------: | :-----------: |
-| RARE    | Chinese | ResNet34_vd | None | 55.39% | 61.90% | 97.05% | 414 s/epoch | 2160 |  [rare_resnet34_ch.yaml](https://github.com/mindspore-lab/mindocr/blob/main/configs/rec/rare/rare_resnet34_ch.yaml) | [ckpt](https://download.mindspore.cn/toolkits/mindocr/rare/rare_resnet34_ch-5f3023e2.ckpt) \| [mindir]() |
+| RARE    | Chinese | ResNet34_vd | None | 62.15% | 67.05% | 97.60% | 414 s/epoch | 2160 |  [rare_resnet34_ch.yaml](https://github.com/mindspore-lab/mindocr/blob/main/configs/rec/rare/rare_resnet34_ch.yaml) | [ckpt](https://download.mindspore.cn/toolkits/mindocr/rare/rare_resnet34_ch-5f3023e2.ckpt) \| [mindir]() |
 </div>
 
 ### Training with Custom Datasets

--- a/configs/rec/rare/README.md
+++ b/configs/rec/rare/README.md
@@ -350,7 +350,7 @@ After training, evaluation results on the benchmark test set are as follows, whe
 
 | **Model** | **Language** | **Backbone** | **Transform Module** | **Scene** | **Web** | **Document** | **Train T.** | **FPS** | **Recipe** | **Download** | 
 | :-----: | :-----:  | :--------: | :------------: | :--------: | :--------: | :--------: | :--------: | :--------: |:---------: | :-----------: |
-| RARE    | Chinese | ResNet34_vd | None | 55.39% | 61.90% | 97.05% | 683 s/epoch | 1493 |  [rare_resnet34_ch.yaml](https://github.com/mindspore-lab/mindocr/blob/main/configs/rec/rare/rare_resnet34_ch.yaml) | [ckpt](https://download.mindspore.cn/toolkits/mindocr/rare/rare_resnet34_ch-780b6d20.ckpt) \| [mindir](https://download.mindspore.cn/toolkits/mindocr/rare/rare_resnet34_ch-780b6d20-017aec13.mindir) |
+| RARE    | Chinese | ResNet34_vd | None | 55.39% | 61.90% | 97.05% | 414 s/epoch | 2160 |  [rare_resnet34_ch.yaml](https://github.com/mindspore-lab/mindocr/blob/main/configs/rec/rare/rare_resnet34_ch.yaml) | [ckpt](https://download.mindspore.cn/toolkits/mindocr/rare/rare_resnet34_ch-5f3023e2.ckpt) \| [mindir]() |
 </div>
 
 ### Training with Custom Datasets

--- a/configs/rec/rare/README_CN.md
+++ b/configs/rec/rare/README_CN.md
@@ -354,7 +354,7 @@ mpirun --allow-run-as-root -n 8 python tools/train.py --config configs/rec/rare/
 
 | **模型** | **语种** | **骨干网络** | **空间变换网络** | **街景类** | **网页类** | **文档类** | **训练时间** | **FPS** | **配置文件** | **模型权重下载** | 
 | :-----: | :-----:  | :--------: | :------------: | :--------: | :--------: | :--------: |:--------: | :--------: |:--------: | :--------: |
-| RARE    | 中文 | ResNet34_vd | 无 |55.39% | 61.90% | 97.05% | 683 s/epoch | 1493 | [rare_resnet34_ch.yaml](https://github.com/mindspore-lab/mindocr/blob/main/configs/rec/rare/rare_resnet34_ch.yaml) | [ckpt](https://download.mindspore.cn/toolkits/mindocr/rare/rare_resnet34_ch-780b6d20.ckpt) \| [mindir](https://download.mindspore.cn/toolkits/mindocr/rare/rare_resnet34_ch-780b6d20-017aec13.mindir) |
+| RARE    | 中文 | ResNet34_vd | 无 |55.39% | 61.90% | 97.05% | 414 s/epoch | 2160 | [rare_resnet34_ch.yaml](https://github.com/mindspore-lab/mindocr/blob/main/configs/rec/rare/rare_resnet34_ch.yaml) | [ckpt](https://download.mindspore.cn/toolkits/mindocr/rare/rare_resnet34_ch-5f3023e2.ckpt) \| [mindir]() |
 </div>
 
 ### 使用自定义数据集进行训练

--- a/configs/rec/rare/README_CN.md
+++ b/configs/rec/rare/README_CN.md
@@ -354,7 +354,7 @@ mpirun --allow-run-as-root -n 8 python tools/train.py --config configs/rec/rare/
 
 | **模型** | **语种** | **骨干网络** | **空间变换网络** | **街景类** | **网页类** | **文档类** | **训练时间** | **FPS** | **配置文件** | **模型权重下载** | 
 | :-----: | :-----:  | :--------: | :------------: | :--------: | :--------: | :--------: |:--------: | :--------: |:--------: | :--------: |
-| RARE    | 中文 | ResNet34_vd | 无 |55.39% | 61.90% | 97.05% | 414 s/epoch | 2160 | [rare_resnet34_ch.yaml](https://github.com/mindspore-lab/mindocr/blob/main/configs/rec/rare/rare_resnet34_ch.yaml) | [ckpt](https://download.mindspore.cn/toolkits/mindocr/rare/rare_resnet34_ch-5f3023e2.ckpt) \| [mindir]() |
+| RARE    | 中文 | ResNet34_vd | 无 | 62.15% | 67.05% | 97.60% | 414 s/epoch | 2160 | [rare_resnet34_ch.yaml](https://github.com/mindspore-lab/mindocr/blob/main/configs/rec/rare/rare_resnet34_ch.yaml) | [ckpt](https://download.mindspore.cn/toolkits/mindocr/rare/rare_resnet34_ch-5f3023e2.ckpt) \| [mindir]() |
 </div>
 
 ### 使用自定义数据集进行训练

--- a/configs/rec/rare/rare_resnet34.yaml
+++ b/configs/rec/rare/rare_resnet34.yaml
@@ -28,6 +28,7 @@ model:
     name: AttentionHead
     hidden_size: 256
     out_channels: *num_classes
+    batch_max_length: *max_text_len
 
 postprocess:
   name: RecAttnLabelDecode

--- a/configs/rec/rare/rare_resnet34_ch.yaml
+++ b/configs/rec/rare/rare_resnet34_ch.yaml
@@ -92,7 +92,7 @@ train:
           lower: False
       - Rotate90IfVertical:
           threshold: 2.0
-          direction: anti_clockwise
+          direction: counterclockwise
       - RecResizeImg:
           image_shape: [32, 320]
           infer_mode: *infer_mode
@@ -136,7 +136,7 @@ eval:
           lower: False
       - Rotate90IfVertical:
           threshold: 2.0
-          direction: anti_clockwise
+          direction: counterclockwise
       - RecResizeImg:
           image_shape: [32, 320]
           infer_mode: *infer_mode

--- a/configs/rec/rare/rare_resnet34_ch.yaml
+++ b/configs/rec/rare/rare_resnet34_ch.yaml
@@ -2,6 +2,7 @@ system:
   mode: 0 # 0 for graph mode, 1 for pynative mode in MindSpore
   distribute: True
   amp_level: O2
+  amp_level_infer: O2 # running inference in O2 mode
   seed: 42
   log_interval: 100
   val_while_train: True

--- a/configs/rec/rare/rare_resnet34_ch.yaml
+++ b/configs/rec/rare/rare_resnet34_ch.yaml
@@ -1,34 +1,35 @@
 system:
   mode: 0 # 0 for graph mode, 1 for pynative mode in MindSpore
   distribute: True
-  amp_level: "O2"
+  amp_level: O2
   seed: 42
   log_interval: 100
   val_while_train: True
   drop_overflow_update: False
+  ckpt_max_keep: 5
 
 common:
   character_dict_path: &character_dict_path mindocr/utils/dict/ch_dict.txt
   num_classes: &num_classes 6625 # num_chars_in_dict + 2
-  max_text_len: &max_text_len 25
+  max_text_len: &max_text_len 40
   infer_mode: &infer_mode False
   use_space_char: &use_space_char False
-  batch_size: &batch_size 512
+  batch_size: &batch_size 256
 
 model:
   type: rec
   transform: null
   backbone:
     name: rec_resnet34
-    pretrained: https://download.mindspore.cn/toolkits/mindocr/rare/rare_resnet34-309dc63e.ckpt
-    remove_prefix: True # remove the prefix "backbone." from the ckpt
+    pretrained: False
   neck:
     name: RNNEncoder
-    hidden_size: 256
+    hidden_size: 64
   head:
     name: AttentionHead
     hidden_size: 256
     out_channels: *num_classes
+    batch_max_length: *max_text_len
 
 postprocess:
   name: RecAttnLabelDecode
@@ -38,6 +39,7 @@ postprocess:
 metric:
   name: RecMetric
   main_indicator: acc
+  lower: False
   character_dict_path: *character_dict_path
   ignore_space: True
   print_flag: False
@@ -47,11 +49,11 @@ loss:
 
 scheduler:
   scheduler: warmup_cosine_decay
-  min_lr: 0.0
-  lr: 0.0005
+  min_lr: 0.00001
+  lr: 0.001
   num_epochs: 60
-  warmup_epochs: 3
-  decay_epochs: 57
+  warmup_epochs: 6
+  decay_epochs: 54
 
 optimizer:
   opt: adamw
@@ -65,17 +67,19 @@ loss_scaler:
   scale_window: 1000
 
 train:
-  ckpt_save_dir: "./tmp_rec"
+  ckpt_save_dir: ./tmp_rec
   dataset_sink_mode: False
-  ema: True
-  ema_decay: 0.99999
+  clip_grad: True
+  clip_norm: 0.1
   dataset:
     type: LMDBDataset
-    dataset_root: path/to/data_lmdb_release/
-    data_dir: ch_benchmark/training/
+    dataset_root: path/to/chinese_text_recognition/
+    data_dir: training/
     label_file: null
     sample_ratio: 1.0
     shuffle: True
+    filter_max_len: True
+    max_text_len: *max_text_len
     transform_pipeline:
       - DecodeImage:
           img_mode: BGR
@@ -84,36 +88,39 @@ train:
           max_text_len: *max_text_len
           character_dict_path: *character_dict_path
           use_space_char: *use_space_char
-          lower: True
-      - RecResizeImg: # different from paddle (paddle converts image from HWC to CHW and rescale to [-1, 1] after resize.
-          image_shape: [32, 320] # H, W
+          lower: False
+      - Rotate90IfVertical:
+          threshold: 2.0
+          direction: anti_clockwise
+      - RecResizeImg:
+          image_shape: [32, 320]
           infer_mode: *infer_mode
           character_dict_path: *character_dict_path
-          padding: False # aspect ratio will be preserved if true.
-      - NormalizeImage: # different from paddle (paddle wrongly normalize BGR image with RGB mean/std from ImageNet for det, and simple rescale to [-1, 1] in rec.
+          padding: True
+      - NormalizeImage:
           bgr_to_rgb: True
           is_hwc: True
           mean: [127.0, 127.0, 127.0]
           std: [127.0, 127.0, 127.0]
       - ToCHWImage:
     output_columns: ["image", "text_seq"]
-    net_input_column_index: [0, 1] # input indices for network forward func in output_columns
-    label_column_index: [1] # input indices marked as label
+    net_input_column_index: [0, 1]
+    label_column_index: [1]
 
   loader:
-    shuffle: True # TODO: tbc
+    shuffle: True
     batch_size: *batch_size
     drop_remainder: True
     max_rowsize: 12
     num_workers: 1
 
 eval:
-  ckpt_load_path: "./tmp_rec/best.ckpt"
+  ckpt_load_path: ./tmp_rec/best.ckpt
   dataset_sink_mode: False
   dataset:
     type: LMDBDataset
-    dataset_root: path/to/data_lmdb_release/
-    data_dir: ch_benchmark/validation/
+    dataset_root: path/to/chinese_text_recognition/
+    data_dir: validation/
     label_file: null
     sample_ratio: 1.0
     shuffle: False
@@ -125,26 +132,28 @@ eval:
           max_text_len: *max_text_len
           character_dict_path: *character_dict_path
           use_space_char: *use_space_char
-          lower: True
-      - RecResizeImg: # different from paddle (paddle converts image from HWC to CHW and rescale to [-1, 1] after resize.
-          image_shape: [32, 320] # H, W
+          lower: False
+      - Rotate90IfVertical:
+          threshold: 2.0
+          direction: anti_clockwise
+      - RecResizeImg:
+          image_shape: [32, 320]
           infer_mode: *infer_mode
           character_dict_path: *character_dict_path
-          padding: False # aspect ratio will be preserved if true.
-      - NormalizeImage: # different from paddle (paddle wrongly normalize BGR image with RGB mean/std from ImageNet for det, and simple rescale to [-1, 1] in rec.
+          padding: True
+      - NormalizeImage:
           bgr_to_rgb: True
           is_hwc: True
           mean: [127.0, 127.0, 127.0]
           std: [127.0, 127.0, 127.0]
       - ToCHWImage:
-    #  the order of the dataloader list, matching the network input and the input labels for the loss function, and optional data for debug/visaulize
     output_columns: ["image", "text_padded", "text_length"]
-    net_input_column_index: [0] # input indices for network forward func in output_columns
-    label_column_index: [1, 2] # input indices marked as label
+    net_input_column_index: [0]
+    label_column_index: [1, 2]
 
   loader:
     shuffle: False
-    batch_size: 512
+    batch_size: 64
     drop_remainder: False
     max_rowsize: 12
     num_workers: 1

--- a/configs/rec/svtr/README.md
+++ b/configs/rec/svtr/README.md
@@ -327,6 +327,39 @@ To use a specific dictionary, set the parameter `character_dict_path` to the pat
 - Remember to check the value of `dataset->transform_pipeline->RecAttnLabelEncode->lower` in the configuration yaml. Set it to False if you prefer case-sensitive encoding.
 
 
+## 5. Chinese Text Recognition Model Training
+
+Currently, this model supports multilingual recognition and provides pre-trained models for different languages. Details are as follows:
+
+### Chinese Dataset Preparation and Configuration
+
+We use a public Chinese text benchmark dataset [Benchmarking-Chinese-Text-Recognition](https://github.com/FudanVI/benchmarking-chinese-text-recognition) for SVTR training and evaluation.
+
+For detailed instruction of data preparation and yaml configuration, please refer to [ch_dataeset](../../../docs/en/datasets/chinese_text_recognition.md).
+
+### Training
+
+To train with the prepared datsets and config file, please run:
+
+```shell
+mpirun --allow-run-as-root -n 4 python tools/train.py --config configs/rec/svtr/svtr_tiny_ch.yaml
+```
+
+### Results and Pretrained Weights
+
+After training, evaluation results on the benchmark test set are as follows, where we also provide the model config and pretrained weights.
+
+<div align="center">
+
+| **Model** | **Language** | **Context**  | **Scene** | **Web** | **Document** | **Train T.** | **FPS** | **Recipe** | **Download** | 
+| :-----: | :-----:  | :--------: | :--------: | :--------: | :--------: | :---------: | :--------: | :---------: | :-----------: |
+| SVTR-Tiny    | Chinese | D910x4-MS1.10-G | 65.93% | 69.64% | 98.01% | 647 s/epoch | 1580 | [svtr_tiny_ch.yaml](https://github.com/mindspore-lab/mindocr/blob/main/configs/rec/svtr/svtr_tiny_ch.yaml) | [ckpt](https://download.mindspore.cn/toolkits/mindocr/svtr/svtr_tiny_ch-2ee6ade4.ckpt) \| [mindir](https://download.mindspore.cn/toolkits/mindocr/svtr/svtr_tiny_ch-2ee6ade4-3e495768.mindir) |
+</div>
+
+### Training with Custom Datasets
+You can train models for different languages with your own custom datasets. Loading the pretrained Chinese model to finetune on your own dataset usually yields better results than training from scratch. Please refer to the tutorial [Training Recognition Network with Custom Datasets](../../../docs/en/tutorials/training_recognition_custom_dataset.md).
+
+
 ## References
 <!--- Guideline: Citation format GB/T 7714 is suggested. -->
 

--- a/configs/rec/svtr/README.md
+++ b/configs/rec/svtr/README.md
@@ -38,7 +38,7 @@ According to our experiments, the evaluation results on public benchmark dataset
 
 | **Model** | **Context** | **Avg Accuracy** | **Train T.** | **FPS** | **Recipe** | **Download** | 
 | :-----: | :-----------: | :--------------: | :----------: | :--------: | :--------: |:----------: |
-| SVTR-Tiny      | D910x4-MS1.10-G | 89.02%    | 4866 s/epoch       | 2968 | [yaml](https://github.com/mindspore-lab/mindocr/blob/main/configs/rec/svtr/svtr_tiny.yaml) | [ckpt](https://download.mindspore.cn/toolkits/mindocr/svtr/svtr_tiny-8542b3bb.ckpt) \| [mindir](https://download.mindspore.cn/toolkits/mindocr/svtr/svtr_tiny-8542b3bb-d5389653.mindir) |
+| SVTR-Tiny      | D910x4-MS1.10-G | 89.02%    | 4866 s/epoch       | 2968 | [yaml](https://github.com/mindspore-lab/mindocr/blob/main/configs/rec/svtr/svtr_tiny.yaml) | [ckpt](https://download.mindspore.cn/toolkits/mindocr/svtr/svtr_tiny-8542b3bb.ckpt) \| [mindir]() |
 </div>
 
 <details open>

--- a/configs/rec/svtr/README_CN.md
+++ b/configs/rec/svtr/README_CN.md
@@ -38,7 +38,7 @@ Table Format:
 
 | **模型** | **环境配置** | **平均准确率** | **训练时间** | **FPS** | **配置文件** | **模型权重下载** | 
 | :-----: | :-----:  | :-----: | :-----: | :-----: |:--------: | :-----: |
-| SVTR-Tiny      | D910x4-MS1.10-G | 89.02%    | 4866 s/epoch        | 2968 | [yaml](https://github.com/mindspore-lab/mindocr/blob/main/configs/rec/svtr/svtr_tiny.yaml) | [ckpt](https://download.mindspore.cn/toolkits/mindocr/svtr/svtr_tiny-8542b3bb.ckpt) \| [mindir](https://download.mindspore.cn/toolkits/mindocr/svtr/svtr_tiny-8542b3bb-d5389653.mindir) |
+| SVTR-Tiny      | D910x4-MS1.10-G | 89.02%    | 4866 s/epoch        | 2968 | [yaml](https://github.com/mindspore-lab/mindocr/blob/main/configs/rec/svtr/svtr_tiny.yaml) | [ckpt](https://download.mindspore.cn/toolkits/mindocr/svtr/svtr_tiny-8542b3bb.ckpt) \| [mindir]() |
 </div>
 
 <details open>

--- a/configs/rec/svtr/README_CN.md
+++ b/configs/rec/svtr/README_CN.md
@@ -324,6 +324,37 @@ Mindocr内置了一部分字典，均放在了 `mindocr/utils/dict/` 位置，�
 - 您可以通过将配置文件中的参数 `use_space_char` 设置为 True 来包含空格字符。
 - 请记住检查配置文件中的 `dataset->transform_pipeline->RecAttnLabelEncode->lower` 参数的值。如果词典中有大小写字母而且想区分大小写的话，请将其设置为 False。
 
+## 5. 中文识别模型训练
+
+目前，SVTR模型支持中英文字识别并提供相应的预训练权重。详细内容如下
+
+### 中文数据集准备及配置
+
+我们采用公开的中文基准数据集[Benchmarking-Chinese-Text-Recognition](https://github.com/FudanVI/benchmarking-chinese-text-recognition)进行SVTR模型的训练和验证。
+
+详细的数据准备和config文件配置方式, 请参考 [中文识别数据集准备](../../../docs/cn/datasets/chinese_text_recognition_CN.md) 
+
+### 模型训练验证
+
+准备好数据集和配置文件后，执行以下命令开启多卡训练
+
+```shell
+mpirun --allow-run-as-root -n 4 python tools/train.py --config configs/rec/svtr/svtr_tiny_ch.yaml
+```
+
+### 评估结果和预训练权重
+模型训练完成后，在测试集不同场景上的准确率评估结果如下。相应的模型配置和预训练权重可通过表中链接下载。
+
+<div align="center">
+
+| **模型** | **语种** | **环境配置** | **街景类** | **网页类** | **文档类** | **训练时间** | **FPS** | **配置文件** | **模型权重下载** | 
+| :-----: | :-----:  | :-------:  | :--------: | :--------: | :--------: | :---------: |:--------: | :---------: | :-----------: |
+| SVTR-Tiny    | 中文 | D910x4-MS1.10-G | 65.93% | 69.64% | 98.01% | 647 s/epoch | 1580 | [svtr_tiny_ch.yaml](https://github.com/mindspore-lab/mindocr/blob/main/configs/rec/svtr/svtr_tiny_ch.yaml) | [ckpt](https://download.mindspore.cn/toolkits/mindocr/svtr/svtr_tiny_ch-2ee6ade4.ckpt) \| [mindir]() |
+</div>
+
+### 使用自定义数据集进行训练
+您可以在自定义的数据集基于提供的预训练权重进行微调训练, 以在特定场景获得更高的识别准确率，具体步骤请参考文档 [使用自定义数据集训练识别网络](../../../docs/cn/tutorials/training_recognition_custom_dataset_CN.md)。
+
 ## 参考文献
 <!--- Guideline: Citation format GB/T 7714 is suggested. -->
 

--- a/configs/rec/svtr/svtr_tiny.yaml
+++ b/configs/rec/svtr/svtr_tiny.yaml
@@ -104,6 +104,7 @@ train:
     type: LMDBDataset
     dataset_root: path/to/data_lmdb_release/
     data_dir: training/
+    label_file: null
     sample_ratio: 1.0
     shuffle: True
     transform_pipeline:
@@ -144,6 +145,7 @@ eval:
     type: LMDBDataset
     dataset_root: path/to/data_lmdb_release/
     data_dir: validation/
+    label_file: null
     sample_ratio: 1.0
     shuffle: False
     transform_pipeline:

--- a/configs/rec/svtr/svtr_tiny_ch.yaml
+++ b/configs/rec/svtr/svtr_tiny_ch.yaml
@@ -10,27 +10,20 @@ system:
   ckpt_max_keep: 5
 
 common:
-  character_dict_path: &character_dict_path
-  num_classes: &num_classes 37 # num_chars_in_dict + 1
-  max_text_len: &max_text_len 24
+  character_dict_path: &character_dict_path mindocr/utils/dict/ch_dict.txt
+  num_classes: &num_classes 6624 # num_chars_in_dict + 1
+  max_text_len: &max_text_len 40
   use_space_char: &use_space_char False
-  batch_size: &batch_size 512
+  batch_size: &batch_size 256
 
 model:
   type: rec
-  transform:
-    name: STN_ON
-    in_channels: 3
-    tps_inputsize: [32, 64]
-    tps_outputsize: [32, 100]
-    num_control_points: 20
-    tps_margins: [0.05, 0.05]
-    stn_activation: none
+  transform: null
   backbone:
     name: SVTRNet
     pretrained: False
-    img_size: [32, 100]
-    out_channels: 192
+    img_size: [32, 320]
+    out_channels: 96
     patch_merging: Conv
     embed_dim: [64, 128, 256]
     depth: [3, 6, 3]
@@ -73,7 +66,7 @@ metric:
 
 loss:
   name: CTCLoss
-  pred_seq_len: 25 # 100 / 4
+  pred_seq_len: 80 # 320 / 4
   max_label_len: *max_text_len # this value should be smaller than pre_seq_len
   batch_size: *batch_size
 
@@ -81,9 +74,9 @@ scheduler:
   scheduler: warmup_cosine_decay
   min_lr: 0.00001
   lr: 0.001
-  num_epochs: 30
-  warmup_epochs: 3
-  decay_epochs: 27
+  num_epochs: 60
+  warmup_epochs: 6
+  decay_epochs: 54
 
 optimizer:
   opt: adamw
@@ -100,26 +93,31 @@ loss_scaler:
 train:
   ckpt_save_dir: ./tmp_rec
   dataset_sink_mode: False
+  clip_grad: True
+  clip_norm: 0.1
   dataset:
     type: LMDBDataset
     dataset_root: path/to/data_lmdb_release/
     data_dir: training/
     sample_ratio: 1.0
     shuffle: True
+    filter_max_len: True
+    max_text_len: *max_text_len
     transform_pipeline:
       - DecodeImage:
           img_mode: BGR
           to_float32: False
-      - SVTRRecAug:
-          aug_type: 0
       - RecCTCLabelEncode:
           max_text_len: *max_text_len
           character_dict_path: *character_dict_path
           use_space_char: *use_space_char
           lower: True
+      - Rotate90IfVertical:
+          threshold: 2.0
+          direction: anti_clockwise
       - SVTRRecResizeImg:
-          image_shape: [64, 256]
-          padding: False
+          image_shape: [32, 320]
+          padding: True
       - NormalizeImage:
           bgr_to_rgb: True
           is_hwc: True
@@ -135,7 +133,7 @@ train:
     batch_size: *batch_size
     drop_remainder: True
     max_rowsize: 12
-    num_workers: 8
+    num_workers: 1
 
 eval:
   ckpt_load_path: ./tmp_rec/best.ckpt
@@ -155,9 +153,12 @@ eval:
           character_dict_path: *character_dict_path
           use_space_char: *use_space_char
           lower: True
+      - Rotate90IfVertical:
+          threshold: 2.0
+          direction: anti_clockwise
       - SVTRRecResizeImg:
-          image_shape: [64, 256]
-          padding: False
+          image_shape: [32, 320] # H, W
+          padding: True
       - NormalizeImage:
           bgr_to_rgb: True
           is_hwc: True
@@ -170,7 +171,7 @@ eval:
 
   loader:
     shuffle: False
-    batch_size: 512
+    batch_size: 64
     drop_remainder: False
     max_rowsize: 12
-    num_workers: 8
+    num_workers: 1

--- a/configs/rec/svtr/svtr_tiny_ch.yaml
+++ b/configs/rec/svtr/svtr_tiny_ch.yaml
@@ -116,7 +116,7 @@ train:
           lower: False
       - Rotate90IfVertical:
           threshold: 2.0
-          direction: anti_clockwise
+          direction: counterclockwise
       - SVTRRecResizeImg:
           image_shape: [32, 320]
           padding: True
@@ -158,7 +158,7 @@ eval:
           lower: False
       - Rotate90IfVertical:
           threshold: 2.0
-          direction: anti_clockwise
+          direction: counterclockwise
       - SVTRRecResizeImg:
           image_shape: [32, 320] # H, W
           padding: True

--- a/configs/rec/svtr/svtr_tiny_ch.yaml
+++ b/configs/rec/svtr/svtr_tiny_ch.yaml
@@ -60,6 +60,7 @@ postprocess:
 metric:
   name: RecMetric
   main_indicator: acc
+  lower: False
   character_dict_path: *character_dict_path
   ignore_space: True
   print_flag: False
@@ -99,6 +100,7 @@ train:
     type: LMDBDataset
     dataset_root: path/to/data_lmdb_release/
     data_dir: training/
+    label_file: null
     sample_ratio: 1.0
     shuffle: True
     filter_max_len: True
@@ -111,7 +113,7 @@ train:
           max_text_len: *max_text_len
           character_dict_path: *character_dict_path
           use_space_char: *use_space_char
-          lower: True
+          lower: False
       - Rotate90IfVertical:
           threshold: 2.0
           direction: anti_clockwise
@@ -142,6 +144,7 @@ eval:
     type: LMDBDataset
     dataset_root: path/to/data_lmdb_release/
     data_dir: validation/
+    label_file: null
     sample_ratio: 1.0
     shuffle: False
     transform_pipeline:
@@ -152,7 +155,7 @@ eval:
           max_text_len: *max_text_len
           character_dict_path: *character_dict_path
           use_space_char: *use_space_char
-          lower: True
+          lower: False
       - Rotate90IfVertical:
           threshold: 2.0
           direction: anti_clockwise

--- a/mindocr/data/transforms/rec_transforms.py
+++ b/mindocr/data/transforms/rec_transforms.py
@@ -6,7 +6,7 @@ import cv2
 import math
 import numpy as np
 
-__all__ = ['RecCTCLabelEncode', 'RecAttnLabelEncode', 'RecResizeImg', 'RecResizeNormForInfer', 'SVTRRecResizeImg']
+__all__ = ['RecCTCLabelEncode', 'RecAttnLabelEncode', 'RecResizeImg', 'RecResizeNormForInfer', 'SVTRRecResizeImg', 'Rotate90IfVertical']
 
 
 class RecCTCLabelEncode(object):
@@ -397,6 +397,30 @@ class RecResizeNormForInfer(object):
         if not self.norm_before_pad:
             data['image'] = self.norm(data['image']) 
 
+        return data
+
+
+class Rotate90IfVertical:
+    """Rotate the image by 90 degree when the height/width ratio is larger than the given threshold.
+    Note: It needs to be called before image resize."""
+    def __init__(self, threshold: float = 2.0, direction: str = 'anti_clockwise',  **kwargs):
+        self.threshold = threshold
+
+        if direction == 'anti_clockwise':
+            self.flag = cv2.ROTATE_90_COUNTERCLOCKWISE
+        elif direction == 'clockwise':
+            self.flag = cv2.ROTATE_90_CLOCKWISE
+        else:
+            raise ValueError("Unsupported direction")
+
+    def __call__(self, data):
+        img = data['image']
+
+        h, w, _ = img.shape
+        if h / w > self.threshold:
+            img = cv2.rotate(img, self.flag)
+
+        data['image'] = img
         return data
 
 

--- a/mindocr/data/transforms/rec_transforms.py
+++ b/mindocr/data/transforms/rec_transforms.py
@@ -403,10 +403,10 @@ class RecResizeNormForInfer(object):
 class Rotate90IfVertical:
     """Rotate the image by 90 degree when the height/width ratio is larger than the given threshold.
     Note: It needs to be called before image resize."""
-    def __init__(self, threshold: float = 2.0, direction: str = 'anti_clockwise',  **kwargs):
+    def __init__(self, threshold: float = 1.5, direction: str = 'counterclockwise',  **kwargs):
         self.threshold = threshold
 
-        if direction == 'anti_clockwise':
+        if direction == 'counterclockwise':
             self.flag = cv2.ROTATE_90_COUNTERCLOCKWISE
         elif direction == 'clockwise':
             self.flag = cv2.ROTATE_90_CLOCKWISE

--- a/mindocr/losses/rec_loss.py
+++ b/mindocr/losses/rec_loss.py
@@ -1,43 +1,38 @@
-import mindspore as ms
-from mindspore import Tensor
-from mindspore import nn
-from mindspore.nn.loss.loss import LossBase
-from mindspore import Tensor, Parameter
-from mindspore.common import dtype as mstype
-from mindspore import ops
 import numpy as np
+import mindspore as ms
+from mindspore import nn
+from mindspore import ops
+from mindspore import Tensor
+from mindspore.nn.loss.loss import LossBase
 
-__all__ = ['CTCLoss']
 
-# TODO: support label_weights for imbalance data
+__all__ = ['CTCLoss', 'AttentionLoss']
+
+
 class CTCLoss(LossBase):
     """
-     CTCLoss definition
+    CTCLoss definition
 
-     Args:
+    Args:
         pred_seq_len(int): the length of the predicted character sequence. For text images, this value equals to W - the width of feature map encoded by the visual bacbkone. This can be obtained by probing the output shape in the network.
             E.g., for a training image in shape (3, 32, 100), the feature map encoded by resnet34 bacbkone is in shape (512, 1, 4), W = 4, sequence len is 4.
         max_label_len(int): the maximum number of characters in a text label, i.e. max_text_len in yaml.
         batch_size(int): batch size of input logits. bs
-     """
+    """
 
-    def __init__(self, pred_seq_len=26, max_label_len=25, batch_size=32, reduction='mean'):
-        super(CTCLoss, self).__init__()
+    def __init__(self, pred_seq_len: int = 26, max_label_len: int = 25, batch_size: int = 32, reduction: str = 'mean') -> None:
+        super(CTCLoss, self).__init__(reduction=reduction)
         assert pred_seq_len > max_label_len, 'pred_seq_len is required to be larger than max_label_len for CTCLoss. Please adjust the strides in the backbone, or reduce max_text_length in yaml'
-        self.sequence_length = Tensor(np.array([pred_seq_len] * batch_size), mstype.int32)
+        self.sequence_length = Tensor(np.array([pred_seq_len] * batch_size), ms.int32)
+
         label_indices = []
         for i in range(batch_size):
             for j in range(max_label_len):
                 label_indices.append([i, j])
-        self.label_indices = Tensor(np.array(label_indices), mstype.int64)
-        #self.reshape = P.Reshape()
+        self.label_indices = Tensor(np.array(label_indices), ms.int64)
         self.ctc_loss = ops.CTCLoss(ctc_merge_repeated=True)
 
-        self.reduction = reduction
-        #print('D: ', self.label_indices.shape)
-
-    # TODO: diff from paddle, paddle takes `label_length` as input too.
-    def construct(self, pred: Tensor, label: Tensor):
+    def construct(self, pred: Tensor, label: Tensor) -> Tensor:
         '''
         Args:
             pred (Tensor): network prediction which is a
@@ -47,42 +42,22 @@ class CTCLoss(LossBase):
             loss value (Tensor)
         '''
         logit = pred
-        #T, bs, nc = logit.shape
-        #logit = ops.reshape(logit, (T*bs, nc))
         label_values = ops.reshape(label, (-1,))
 
         loss, _ = self.ctc_loss(logit, self.label_indices, label_values, self.sequence_length)
-
-        if self.reduction=='mean':
-            loss = loss.mean()
-
+        loss = self.get_loss(loss)
         return loss
 
 
 class AttentionLoss(LossBase):
-    def __init__(self, reduction='mean'):
+    def __init__(self, reduction: str = 'mean') -> None:
         super().__init__()
-        # ignore <GO> symbol
+        # ignore <GO> symbol, assume it is placed at 0th index
         self.criterion = nn.CrossEntropyLoss(reduction=reduction, ignore_index=0)
 
-    def construct(self, logits, labels):
+    def construct(self, logits: Tensor, labels: Tensor) -> Tensor:
         labels = labels[:, 1:]  # wihout <GO> symbol
         num_classes = logits.shape[-1]
         logits = ops.reshape(logits, (-1, num_classes))
         labels = ops.reshape(labels, (-1,))
         return self.criterion(logits, labels)
-
-
-if __name__ == '__main__':
-    max_text_length = 23
-    nc = 26
-    bs = 32
-    pred_seq_len  = 24
-
-    loss_fn = CTCLoss(pred_seq_len, max_text_length, bs)
-
-    x = ms.Tensor(np.random.rand(pred_seq_len, bs, nc), dtype=ms.float32)
-    label = ms.Tensor(np.random.randint(0, nc,  size=(bs, max_text_length)), dtype=ms.int32)
-
-    loss = loss_fn(x, label)
-    print(loss)

--- a/mindocr/models/rec_crnn.py
+++ b/mindocr/models/rec_crnn.py
@@ -21,7 +21,8 @@ default_cfgs = {
     'crnn_vgg7': _cfg(
         url='https://download.mindspore.cn/toolkits/mindocr/crnn/crnn_vgg7-ea7e996c.ckpt'),
     'crnn_resnet34_ch': _cfg(
-        url='https://download.mindspore.cn/toolkits/mindocr/crnn/crnn_resnet34_ch-a8d0f5d3.ckpt'),
+        url='https://download.mindspore.cn/toolkits/mindocr/crnn/crnn_resnet34_ch-7a342e3c.ckpt',
+        input_size=(3, 32, 320)),
     }
 
 
@@ -95,7 +96,7 @@ def crnn_resnet34_ch(pretrained=False, **kwargs):
         },
         "neck": {
             "name": 'RNNEncoder',
-            "hidden_size": 256,
+            "hidden_size": 64,
         },
         "head": {
             "name": 'CTCHead',

--- a/mindocr/models/rec_rare.py
+++ b/mindocr/models/rec_rare.py
@@ -66,7 +66,7 @@ def rare_resnet34_ch(pretrained=False, **kwargs):
         },
         "neck": {
             "name": 'RNNEncoder',
-            "hidden_size": 256,
+            "hidden_size": 64,
         },
         "head": {
             "name": 'AttentionHead',

--- a/mindocr/models/rec_rare.py
+++ b/mindocr/models/rec_rare.py
@@ -19,7 +19,7 @@ default_cfgs = {
         url="https://download.mindspore.cn/toolkits/mindocr/rare/rare_resnet34-309dc63e.ckpt",
     ),
     "rare_resnet34_ch": _cfg(
-        url="https://download.mindspore.cn/toolkits/mindocr/rare/rare_resnet34_ch-780b6d20.ckpt",
+        url="https://download.mindspore.cn/toolkits/mindocr/rare/rare_resnet34_ch-5f3023e2.ckpt",
         input_size=(3, 32, 320),
     ),
 }

--- a/mindocr/models/rec_svtr.py
+++ b/mindocr/models/rec_svtr.py
@@ -13,6 +13,7 @@ def _cfg(url="", input_size=(3, 32, 100), **kwargs):
 default_cfgs = {
     "svtr_tiny": _cfg(
         url="https://download.mindspore.cn/toolkits/mindocr/svtr/svtr_tiny-8542b3bb.ckpt",
+        input_size=(3, 64, 256),
     ),
     "svtr_tiny_ch": _cfg(
         url="https://download.mindspore.cn/toolkits/mindocr/svtr/svtr_tiny_ch-2ee6ade4.ckpt",

--- a/mindocr/models/rec_svtr.py
+++ b/mindocr/models/rec_svtr.py
@@ -3,7 +3,7 @@ from .backbones.mindcv_models.utils import load_pretrained
 from .base_model import BaseModel
 
 
-__all__ = ["SVTR", "svtr_tiny"]
+__all__ = ["SVTR", "svtr_tiny", "svtr_tiny_ch"]
 
 
 def _cfg(url="", input_size=(3, 32, 100), **kwargs):
@@ -14,6 +14,10 @@ default_cfgs = {
     "svtr_tiny": _cfg(
         url="https://download.mindspore.cn/toolkits/mindocr/svtr/svtr_tiny-8542b3bb.ckpt",
     ),
+    "svtr_tiny_ch": _cfg(
+        url="https://download.mindspore.cn/toolkits/mindocr/svtr/svtr_tiny_ch-2ee6ade4.ckpt",
+        input_size=(3, 32, 320),
+    )
 }
 
 
@@ -73,6 +77,53 @@ def svtr_tiny(pretrained=False, **kwargs):
     # load pretrained weights
     if pretrained:
         default_cfg = default_cfgs["svtr_tiny"]
+        load_pretrained(model, default_cfg)
+
+    return model
+
+
+@register_model
+def svtr_tiny_ch(pretrained=False, **kwargs):
+    model_config = {
+        "backbone": {
+            "name": "SVTRNet",
+            "pretrained": False,
+            "img_size": [32, 320],
+            "out_channels": 96,
+            "patch_merging": "Conv",
+            "embed_dim": [64, 128, 256],
+            "depth": [3, 6, 3],
+            "num_heads": [2, 4, 8],
+            "mixer": [
+                "Local",
+                "Local",
+                "Local",
+                "Local",
+                "Local",
+                "Local",
+                "Global",
+                "Global",
+                "Global",
+                "Global",
+                "Global",
+                "Global",
+            ],
+            "local_mixer": [[7, 11], [7, 11], [7, 11]],
+            "last_stage": True,
+            "prenorm": False,
+        },
+        "neck": {"name": "Img2Seq"},
+        "head": {
+            "name": "CTCHead",
+            "out_channels": 6624,
+        },
+    }
+
+    model = SVTR(model_config)
+
+    # load pretrained weights
+    if pretrained:
+        default_cfg = default_cfgs["svtr_tiny_ch"]
         load_pretrained(model, default_cfg)
 
     return model

--- a/mindocr/models/transforms/tps_spatial_transformer.py
+++ b/mindocr/models/transforms/tps_spatial_transformer.py
@@ -20,7 +20,7 @@ def grid_sample(input: Tensor, grid: Tensor, canvas: Optional[Tensor] = None) ->
 
 
 def build_output_control_points(
-    num_control_points: int, margins: Tuple[int, int]
+    num_control_points: int, margins: Tuple[float, float]
 ) -> np.ndarray:
     margin_x, margin_y = margins
     num_ctrl_pts_per_side = num_control_points // 2
@@ -52,7 +52,7 @@ class TPSSpatialTransformer(nn.Cell):
         self,
         output_image_size: Tuple[int, int] = [32, 100],
         num_control_points: int = 20,
-        margins: Tuple[int, int] = [0.05, 0.05],
+        margins: Tuple[float, float] = [0.05, 0.05],
     ):
         super(TPSSpatialTransformer, self).__init__()
         self.output_image_size = output_image_size

--- a/mindocr/postprocess/rec_postprocess.py
+++ b/mindocr/postprocess/rec_postprocess.py
@@ -104,6 +104,9 @@ class RecCTCLabelDecode(object):
             if len(conf_list) == 0:
                 conf_list = [0]
 
+            if self.lower:
+                char_list = [x.lower() for x in char_list]
+
             text = ''.join(char_list)
 
             #result_list.append((text, np.mean(conf_list).tolist()))
@@ -143,8 +146,7 @@ class RecCTCLabelDecode(object):
 
 
 class RecAttnLabelDecode:
-    def __init__(self, 
-                 max_text_len: int = 25,
+    def __init__(self,
                  character_dict_path: Optional[str] = None,
                  use_space_char: bool = False,
                  lower: bool = False
@@ -153,7 +155,6 @@ class RecAttnLabelDecode:
         Convert text label (str) to a sequence of character indices according to the char dictionary
 
         Args:
-            max_text_len: to pad the label text to a fixed length (max_text_len) of text for attn loss computate.
             character_dict_path: path to dictionary, if None, a dictionary containing 36 chars (i.e., "0123456789abcdefghijklmnopqrstuvwxyz") will be used.
             use_space_char(bool): if True, add space char to the dict to recognize the space in between two words
             lower (bool): if True, all upper-case chars in the label text will be converted to lower case. Set to be True if dictionary only contains lower-case chars. Set to be False if not and want to recognition both upper-case and lower-case.
@@ -164,7 +165,6 @@ class RecAttnLabelDecode:
             num_valid_chars: the number of valid characters (including space char if used) in the dictionary
             num_classes: the number of classes (which valid characters char and the speical token for blank padding). so num_classes = num_valid_chars + 1
         """
-        self.max_text_len = max_text_len
         self.lower = lower
 
         # read dict
@@ -208,8 +208,12 @@ class RecAttnLabelDecode:
     
         batch_size = len(char_indices)
         for batch_idx in range(batch_size):
-            text = [self.character[i] for i in char_indices[batch_idx]]
-            text = ''.join(text)
+            char_list = [self.character[i] for i in char_indices[batch_idx]]
+
+            if self.lower:
+                char_list = [x.lower() for x in char_list]
+
+            text = ''.join(char_list)
 
             pred_EOS = text.find('<STOP>')
 

--- a/requirements/modelarts.txt
+++ b/requirements/modelarts.txt
@@ -11,3 +11,4 @@ opencv-python-headless==3.4.18.65
 Pillow==9.1.1
 PyYAML==6.0
 xml-python==0.4.3
+lanms>=1.0.2

--- a/tools/export.py
+++ b/tools/export.py
@@ -100,7 +100,8 @@ if __name__ == '__main__':
     parser.add_argument(
         '--amp_level',
         type=str,
-        default="O0",
+        required=True,
+        choices=['O0', 'O1', 'O2', 'O3'],
         help='AMP Level for the network to be exported.')
 
     args = parser.parse_args()

--- a/tools/export.py
+++ b/tools/export.py
@@ -34,7 +34,7 @@ from mindocr import list_models, build_model
 import numpy as np
 
 
-def export(name_or_config, data_shape, local_ckpt_path="", save_dir=""):
+def export(name_or_config, data_shape, local_ckpt_path="", save_dir="", amp_level="O2"):
     ms.set_context(mode=ms.GRAPH_MODE) #, device_target='Ascend')
 
     if name_or_config.endswith('.yml') or name_or_config.endswith('.yaml'):
@@ -50,6 +50,10 @@ def export(name_or_config, data_shape, local_ckpt_path="", save_dir=""):
         net = build_model(model_cfg, pretrained=False, ckpt_load_path=local_ckpt_path)
     else:
         net = build_model(model_cfg, pretrained=True)
+
+    if amp_level in ["O1", "O2", "O3"]:
+        print(f"Set the AMP level of the model to be `{amp_level}`.")
+        net = ms.amp.auto_mixed_precision(net, amp_level=amp_level)
 
     net.set_train(False)
 
@@ -75,15 +79,12 @@ if __name__ == '__main__':
     parser.add_argument(
         '--model_name',
         type=str,
-        default="",
         required=True,
-        #choices=list_models(),
         help=f'Name of the model to be converted or the path to model YAML config file. Available choices for names: {list_models()}.')
     parser.add_argument(
         '--data_shape',
         type=int,
         nargs=2,
-        default="",
         required=True,
         help=f'The data shape [H, W] for exporting mindir files. It is recommended to be the same as the rescaled data shape in evaluation to get the best inference performance.')
     parser.add_argument(
@@ -96,8 +97,13 @@ if __name__ == '__main__':
         type=str,
         default="",
         help='Directory to save the exported mindir file.')
+    parser.add_argument(
+        '--amp_level',
+        type=str,
+        default="O0",
+        help='AMP Level for the network to be exported.')
 
     args = parser.parse_args()
     check_args(args)
 
-    export(args.model_name, args.data_shape, args.local_ckpt_path, args.save_dir)
+    export(args.model_name, args.data_shape, args.local_ckpt_path, args.save_dir, amp_level=args.amp_level)

--- a/tools/export.py
+++ b/tools/export.py
@@ -34,7 +34,7 @@ from mindocr import list_models, build_model
 import numpy as np
 
 
-def export(name_or_config, data_shape, local_ckpt_path="", save_dir="", amp_level="O2"):
+def export(name_or_config, data_shape, local_ckpt_path="", save_dir="", amp_level="O0"):
     ms.set_context(mode=ms.GRAPH_MODE) #, device_target='Ascend')
 
     if name_or_config.endswith('.yml') or name_or_config.endswith('.yaml'):


### PR DESCRIPTION
1. CRNN Model improvement
Scene: 59.71% -> 60.45%
Web: 64.86% -> 65.95%
Document: 89.23% -> 97.68%

2. Seq2Seq Model Improvement
Scene: 55.39% -> 62.15%
Web: 61.90% -> 67.05%
Document: 97.05% -> 97.60%
FPS: 1493 -> 2160

2. Add SVTR Model
Scene: 65.93%
Web: 69.64%
Document: 98.01%

4. Chinese benchmark model supported vertical image recognition

5. Support filtering the samples when the label length is larger than the `max_label_len` during training

6. Add AMP convert during model export



Thank you for your contribution to the MindOCR repo.
Before submitting this PR, please make sure:

- [x] You have read the [Contributing Guidelines on pull requests](https://github.com/mindspore-lab/mindcv/blob/main/CONTRIBUTING.md)
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved terminology
- [ ] You have added unit tests

## Motivation

(Write your motivation for proposed changes here.)

## Test Plan

(How should this PR be tested? Do you require special setup to run the test or repro the fixed bug?)

## Related Issues and PRs

(Is this PR part of a group of changes? Link the other relevant PRs and Issues here. Use https://help.github.com/en/articles/closing-issues-using-keywords for help on GitHub syntax)
