### PR TITLE
refactor param amp_level usage when build_model, remove export.py input args.amp_level

### DIFF
--- a/mindocr/models/builder.py
+++ b/mindocr/models/builder.py
@@ -3,6 +3,8 @@ build models
 """
 from typing import Union
 
+from mindspore.amp import auto_mixed_precision
+
 from ._registry import is_model, list_models, model_entrypoint
 from .base_model import BaseModel
 from .utils import load_model
@@ -69,5 +71,8 @@ def build_model(name_or_config: Union[str, dict], **kwargs):
             )
 
         load_model(network, load_from)
+
+    if "amp_level" in kwargs:
+        auto_mixed_precision(network, amp_level=kwargs["amp_level"])
 
     return network

--- a/tests/ut/test_mindir_export.py
+++ b/tests/ut/test_mindir_export.py
@@ -23,7 +23,7 @@ def test_mindir_infer(model_name):
     else:
         c, h, w = 3, 736, 1280
 
-    export(model_name, [h, w])
+    export(model_name, [h, w], local_ckpt_path="", save_dir="")
 
     fn = f"{model_name}.mindir"
     graph = ms.load(fn)

--- a/tools/benchmarking/multi_dataset_eval.py
+++ b/tools/benchmarking/multi_dataset_eval.py
@@ -81,14 +81,12 @@ def main(cfg):
 
     # model
     cfg.model.backbone.pretrained = False
-    network = build_model(cfg.model, ckpt_load_path=cfg.eval.ckpt_load_path)
+    amp_level = cfg.system.get("amp_level_infer", "O0")
+    network = build_model(cfg.model, ckpt_load_path=cfg.eval.ckpt_load_path, amp_level=amp_level)
     network.set_train(False)
 
     if not cfg.system.amp_level_infer and cfg.system.amp_level != "O0":
         print("INFO: Evaluation will run in full-precision(fp32)")
-
-    if cfg.system.amp_level_infer:
-        ms.amp.auto_mixed_precision(network, amp_level=cfg.system.amp_level_infer)
 
     # postprocess, metric
     postprocessor = build_postprocess(cfg.postprocess)

--- a/tools/eval.py
+++ b/tools/eval.py
@@ -58,13 +58,9 @@ def main(cfg):
 
     # model
     cfg.model.backbone.pretrained = False
-    network = build_model(cfg.model, ckpt_load_path=cfg.eval.ckpt_load_path)
+    amp_level = cfg.system.get("amp_level_infer", "O0")
+    network = build_model(cfg.model, ckpt_load_path=cfg.eval.ckpt_load_path, amp_level=amp_level)
     network.set_train(False)
-
-    amp_level = "O0"
-    if cfg.system.amp_level_infer in ["O1", "O2", "O3"]:
-        ms.amp.auto_mixed_precision(network, amp_level=cfg.system.amp_level_infer)
-        amp_level = cfg.system.amp_level_infer
 
     # postprocess, metric
     postprocessor = build_postprocess(cfg.postprocess)

--- a/tools/infer/text/config.py
+++ b/tools/infer/text/config.py
@@ -50,6 +50,13 @@ def create_parser():
         help="detection algorithm.",
     )  # determine the network architecture
     parser.add_argument(
+        "--det_amp_level",
+        type=str,
+        default="O0",
+        choices=["O0", "O1", "O2", "O3"],
+        help="Auto Mixed Precision level. This setting only works on GPU and Ascend",
+    )  # added
+    parser.add_argument(
         "--det_model_dir",
         type=str,
         default=None,
@@ -95,7 +102,7 @@ def create_parser():
         "--rec_amp_level",
         type=str,
         default="O0",
-        choices=["O0", "O2", "O3"],
+        choices=["O0", "O1", "O2", "O3"],
         help="Auto Mixed Precision level. This setting only works on GPU and Ascend",
     )  # added
     parser.add_argument(

--- a/tools/infer/text/predict_det.py
+++ b/tools/infer/text/predict_det.py
@@ -51,7 +51,9 @@ class TextDetector(object):
             f"Supported detection algorithms are {list(algo_to_model_name.keys())}"
         )
         model_name = algo_to_model_name[args.det_algorithm]
-        self.model = build_model(model_name, pretrained=pretrained, ckpt_load_path=ckpt_load_path)
+        self.model = build_model(
+            model_name, pretrained=pretrained, ckpt_load_path=ckpt_load_path, amp_level=args.det_amp_level
+        )
         self.model.set_train(False)
         print(
             "INFO: Init detection model: {} --> {}. Model weights loaded from {}".format(

--- a/tools/infer/text/predict_rec.py
+++ b/tools/infer/text/predict_rec.py
@@ -62,9 +62,6 @@ class TextRecognizer(object):
         )
         model_name = algo_to_model_name[args.rec_algorithm]
 
-        self.model = build_model(model_name, pretrained=pretrained, ckpt_load_path=ckpt_load_path)
-        self.model.set_train(False)
-
         # amp_level = 'O2' if args.rec_algorithm.startswith('SVTR') else args.rec_amp_level
         amp_level = args.rec_amp_level
         if args.rec_algorithm.startswith("SVTR") and amp_level != "O2":
@@ -73,7 +70,10 @@ class TextRecognizer(object):
                 "ampl_level for rec model is changed to O2"
             )
             amp_level = "O2"
-        ms.amp.auto_mixed_precision(self.model, amp_level=amp_level)
+
+        self.model = build_model(model_name, pretrained=pretrained, ckpt_load_path=ckpt_load_path, amp_level=amp_level)
+        self.model.set_train(False)
+
         self.cast_pred_fp32 = amp_level != "O0"
         if self.cast_pred_fp32:
             self.cast = ops.Cast()

--- a/tools/train.py
+++ b/tools/train.py
@@ -81,10 +81,8 @@ def main(cfg):
         )
 
     # create model
-    network = build_model(cfg.model, ckpt_load_path=cfg.model.pop("pretrained", None))
-
     amp_level = cfg.system.get("amp_level", "O0")
-    ms.amp.auto_mixed_precision(network, amp_level=amp_level)
+    network = build_model(cfg.model, ckpt_load_path=cfg.model.pop("pretrained", None), amp_level=amp_level)
 
     # create loss
     loss_fn = build_loss(cfg.loss.pop("name"), **cfg["loss"])
@@ -200,7 +198,7 @@ def main(cfg):
         f"Num epochs: {cfg.scheduler.num_epochs}\n"
         f"Clip gradient: {clip_grad}\n"
         f"EMA: {use_ema}\n"
-        f"AMP level: {cfg.system.amp_level}\n"
+        f"AMP level: {amp_level}\n"
         f"Loss scaler: {cfg.loss_scaler}\n"
         f"Drop overflow update: {cfg.system.drop_overflow_update}\n"
         f"{info_seg}\n"


### PR DESCRIPTION
Thank you for your contribution to the MindOCR repo.
Before submitting this PR, please make sure:

- [x] You have read the [Contributing Guidelines on pull requests](https://github.com/mindspore-lab/mindcv/blob/main/CONTRIBUTING.md)
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved terminology
- [x] You have added unit tests

## Motivation
- set the network's amp_level inside `build_model()` instead of outside 
- remove export.py input `args.amp_level`, load the `system.amp_level_infer` from input yaml (if export using yaml)