### PR TITLE
fix bugs when inference using DBPostprocess and ScalePadImage

### DIFF
--- a/mindocr/data/transforms/det_transforms.py
+++ b/mindocr/data/transforms/det_transforms.py
@@ -356,7 +356,7 @@ class DetResize(object):
         self.divisor = divisor
 
         self.is_train = kwargs.get('is_train', False)
-
+        assert target_size is None or limit_type is None, "Only one of limit_type and target_size should be provided."
         if limit_type in ['min', 'max']:
             keep_ratio = True
             padding = False
@@ -407,6 +407,9 @@ class DetResize(object):
         if (self.limit_type in ['min', 'max']) or (self.target_size and self.keep_ratio):
             resize_w = math.ceil(w * scale_ratio)
             resize_h = math.ceil(h * scale_ratio)
+            if self.target_size:
+                resize_w = min(resize_w, tar_w)
+                resize_h = min(resize_h, tar_h)
         elif self.target_size:
             resize_w = tar_w
             resize_h = tar_h

--- a/mindocr/postprocess/det_db_postprocess.py
+++ b/mindocr/postprocess/det_db_postprocess.py
@@ -68,7 +68,10 @@ class DBPostprocess(DetBasePostprocess):
             pred = pred[self._names[self._name]]
         if isinstance(pred, Tensor):
             pred = pred.asnumpy()
-        pred = pred.squeeze(1)
+        if len(pred.shape) == 4 and pred.shape[1] != 1:  # pred shape (N, 3, H, W)
+            pred = pred[:, :1, :, :]  # only need the first output
+        if len(pred.shape) == 4:  # handle pred shape: (N, H, W) skip
+            pred = pred.squeeze(1)
 
         segmentation = pred >= self._binary_thresh
 

--- a/mindocr/postprocess/det_pse_postprocess.py
+++ b/mindocr/postprocess/det_pse_postprocess.py
@@ -91,6 +91,14 @@ class PSEPostprocess(DetBasePostprocess):
             if self._box_type == "quad":
                 rect = cv2.minAreaRect(points)
                 bbox = cv2.boxPoints(rect)
+            elif self._box_type == 'poly':
+                box_height = np.max(points[:, 1]) + 10
+                box_width = np.max(points[:, 0]) + 10
+                mask = np.zeros((box_height, box_width), np.uint8)
+                mask[points[:, 1], points[:, 0]] = 255
+                contours, _ = cv2.findContours(mask, cv2.RETR_EXTERNAL,
+                                               cv2.CHAIN_APPROX_SIMPLE)
+                bbox = np.squeeze(contours[0], 1)
             else:
                 raise NotImplementedError(
                     f"The value of param 'box_type' can only be 'quad', but got '{self._box_type}'."


### PR DESCRIPTION
…t Poly type in PSE postprocess

Thank you for your contribution to the MindOCR repo.
Before submitting this PR, please make sure:

- [x] You have read the [Contributing Guidelines on pull requests](https://github.com/mindspore-lab/mindcv/blob/main/CONTRIBUTING.md)
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved terminology
- [ ] You have added unit tests

## Motivation
fix bugs when inference using DBPostprocess: 
 handle with shape (N, 1, H, W), (N, 3, H, W), (N, H, W)

fix bugs when inference using ScalePadImage:
resize_h and resize_w may be larger than tar_h, tar_w

make PSE postprocess type support poly type 
## Test Plan

(How should this PR be tested? Do you require special setup to run the test or repro the fixed bug?)

## Related Issues and PRs

(Is this PR part of a group of changes? Link the other relevant PRs and Issues here. Use https://help.github.com/en/articles/closing-issues-using-keywords for help on GitHub syntax)
