### PR TITLE
fix bug in convert.py caused by flake8 check

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -19,6 +19,7 @@ per-file-ignores =
     tools/infer/text/parallel/predict_system.py:E402
     tools/infer/text/predict_system.py:E402
     tools/infer/text/predict_rec.py:E402
+    tools/dataset_converters/convert.py:F401,F403
     deploy/demo/mindocr_lite/infer.py:E402
     deploy/models_utils/auto_scaling/converter.py:E402
     mindocr/data/transforms/transforms_factory.py:F401,F403

--- a/mindocr/metrics/builder.py
+++ b/mindocr/metrics/builder.py
@@ -1,7 +1,7 @@
 from . import cls_metrics, det_metrics, rec_metrics
 from .cls_metrics import *
-from .det_metrics import *  # noqa
-from .rec_metrics import *  # noqa
+from .det_metrics import *
+from .rec_metrics import *
 
 __all__ = ["build_metric"]
 

--- a/tools/dataset_converters/convert.py
+++ b/tools/dataset_converters/convert.py
@@ -17,6 +17,14 @@ Example:
 import argparse
 import os
 
+from ctw1500 import CTW1500_Converter
+from ic15 import IC15_Converter
+from mlt2017 import MLT2017_Converter
+from svt import SVT_Converter
+from syntext150k import SYNTEXT150K_Converter
+from td500 import TD500_Converter
+from totaltext import TOTALTEXT_Converter
+
 supported_datasets = ["ic15", "totaltext", "mlt2017", "syntext150k", "svt", "td500", "ctw1500"]
 
 


### PR DESCRIPTION
Thank you for your contribution to the MindOCR repo.
Before submitting this PR, please make sure:

- [x] You have read the [Contributing Guidelines on pull requests](https://github.com/mindspore-lab/mindcv/blob/main/CONTRIBUTING.md)
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved terminology
- [x] You have added unit tests

## Motivation

add rule in .flake8 to avoid checking the module imported but unused in convert.py