### PR TITLE
fix infer args

### DIFF
--- a/configs/det/dbnet/README.md
+++ b/configs/det/dbnet/README.md
@@ -398,7 +398,7 @@ python infer.py \
     --device=Ascend \
     --device_id=0 \
     --det_model_path=your_path_to/output.mindir \
-    --det_config_path=../../configs/det/dbnet/db_r50_icdar15.yaml \
+    --det_model_name_or_config=../../configs/det/dbnet/db_r50_icdar15.yaml \
     --backend=lite \
     --res_save_dir=results_dir
 ```

--- a/configs/det/dbnet/README_CN.md
+++ b/configs/det/dbnet/README_CN.md
@@ -376,7 +376,7 @@ python infer.py \
     --device=Ascend \
     --device_id=0 \
     --det_model_path=your_path_to/output.mindir \
-    --det_config_path=../../configs/det/dbnet/db_r50_icdar15.yaml \
+    --det_model_name_or_config=../../configs/det/dbnet/db_r50_icdar15.yaml \
     --backend=lite \
     --res_save_dir=results_dir
 ```

--- a/configs/det/east/README.md
+++ b/configs/det/east/README.md
@@ -187,7 +187,7 @@ python infer.py \
     --device=Ascend \
     --device_id=0 \
     --det_model_path=your_path_to/output.mindir \
-    --det_config_path=../../configs/det/east/east_r50_icdar15.yaml \
+    --det_model_name_or_config=../../configs/det/east/east_r50_icdar15.yaml \
     --backend=lite \
     --res_save_dir=results_dir
 ```

--- a/configs/det/east/README_CN.md
+++ b/configs/det/east/README_CN.md
@@ -182,7 +182,7 @@ python infer.py \
     --device=Ascend \
     --device_id=0 \
     --det_model_path=your_path_to/output.mindir \
-    --det_config_path=../../configs/det/east/east_r50_icdar15.yaml \
+    --det_model_name_or_config=../../configs/det/east/east_r50_icdar15.yaml \
     --backend=lite \
     --res_save_dir=results_dir
 ```

--- a/configs/det/psenet/README.md
+++ b/configs/det/psenet/README.md
@@ -218,7 +218,7 @@ python infer.py \
     --device=Ascend \
     --device_id=0 \
     --det_model_path=your_path_to/output.mindir \
-    --det_config_path=../../configs/det/psenet/pse_r152_icdar15.yaml \
+    --det_model_name_or_config=../../configs/det/psenet/pse_r152_icdar15.yaml \
     --backend=lite \
     --res_save_dir=results_dir
 ```

--- a/configs/det/psenet/README_CN.md
+++ b/configs/det/psenet/README_CN.md
@@ -217,7 +217,7 @@ python infer.py \
     --device=Ascend \
     --device_id=0 \
     --det_model_path=your_path_to/output.mindir \
-    --det_config_path=../../configs/det/psenet/pse_r152_icdar15.yaml \
+    --det_model_name_or_config=../../configs/det/psenet/pse_r152_icdar15.yaml \
     --backend=lite \
     --res_save_dir=results_dir
 ```

--- a/deploy/py_infer/src/infer_args.py
+++ b/deploy/py_infer/src/infer_args.py
@@ -43,16 +43,19 @@ def get_args():
     )
 
     parser.add_argument("--det_model_path", type=str, required=False, help="Detection model file path.")
-    parser.add_argument("--det_model_name", type=str, required=False, help="Detection model name.")
-    parser.add_argument("--det_config_path", type=str, required=False, help="Detection config file path.")
+    parser.add_argument(
+        "--det_model_name_or_config", type=str, required=False, help="Detection model name or config file path."
+    )
 
     parser.add_argument("--cls_model_path", type=str, required=False, help="Classification model file path.")
-    parser.add_argument("--cls_model_name", type=str, required=False, help="Classification model name.")
-    parser.add_argument("--cls_config_path", type=str, required=False, help="Classification config file path.")
+    parser.add_argument(
+        "--cls_model_name_or_config", type=str, required=False, help="Classification model name or config file path."
+    )
 
     parser.add_argument("--rec_model_path", type=str, required=False, help="Recognition model file path or directory.")
-    parser.add_argument("--rec_model_name", type=str, required=False, help="Recognition model name.")
-    parser.add_argument("--rec_config_path", type=str, required=False, help="Recognition config file path.")
+    parser.add_argument(
+        "--rec_model_name_or_config", type=str, required=False, help="Recognition model name or config file path."
+    )
     parser.add_argument(
         "--character_dict_path", type=str, required=False, help="Character dict file path for recognition models."
     )
@@ -134,6 +137,13 @@ def update_task_info(args):
             f"Please check model_path!"
         )
 
+    if args.det_model_name_or_config:
+        setattr(args, "det_config_path", get_config_by_name_for_model(args.det_model_name_or_config))
+    if args.cls_model_name_or_config:
+        setattr(args, "cls_config_path", get_config_by_name_for_model(args.cls_model_name_or_config))
+    if args.rec_model_name_or_config:
+        setattr(args, "rec_config_path", get_config_by_name_for_model(args.rec_model_name_or_config))
+
     return args
 
 
@@ -144,26 +154,14 @@ def check_and_update_args(args):
     if not args.input_images_dir or not os.path.exists(args.input_images_dir):
         raise ValueError("input_images_dir must be dir containing multiple images or path of single image.")
 
-    if args.det_model_path and not os.path.isfile(args.det_model_path):
-        raise ValueError("det_model_path must be a model file path for detection.")
+    if args.det_model_path and not args.det_model_name_or_config:
+        raise ValueError("det_model_name_or_config can't be emtpy when set det_model_path for detection.")
 
-    if args.det_model_path and (not args.det_model_name and not args.det_config_path):
-        raise ValueError("det_model_name or det_config_path can't be emtpy when set det_model_path for detection.")
+    if args.cls_model_path and not args.cls_model_name_or_config:
+        raise ValueError("cls_model_name_or_config can't be emtpy when set cls_model_path for classification.")
 
-    if args.cls_model_path and not os.path.isfile(args.cls_model_path):
-        raise ValueError("cls_model_path must be a model file path for classification.")
-
-    if args.cls_model_path and (not args.cls_model_name and not args.cls_config_path):
-        raise ValueError("cls_model_name or cls_config_path can't be emtpy when set cls_model_path for classification.")
-
-    if args.rec_model_path and (
-        not os.path.exists(args.rec_model_path)
-        or (os.path.isdir(args.rec_model_path) and not os.listdir(args.rec_model_path))
-    ):
-        raise ValueError("rec_model_path must be a model file or dir containing model file for recognition model.")
-
-    if args.rec_model_path and (not args.rec_model_name and not args.rec_config_path):
-        raise ValueError("rec_model_name or rec_config_path can't be emtpy when set rec_model_path for recognition.")
+    if args.rec_model_path and not args.rec_model_name_or_config:
+        raise ValueError("rec_model_name_or_config can't be emtpy when set rec_model_path for recognition.")
 
     if args.parallel_num < 1 or args.parallel_num > 4:
         raise ValueError(f"parallel_num must between [1,4], current: {args.parallel_num}.")
@@ -183,15 +181,27 @@ def check_and_update_args(args):
     if not args.res_save_dir:
         raise ValueError("res_save_dir can't be empty.")
 
-    need_check_file_exist = {
-        "det_config_path": args.det_config_path,
-        "cls_config_path": args.cls_config_path,
-        "rec_config_path": args.rec_config_path,
+    need_check_file = {
+        "det_model_path": args.det_model_path,
+        "cls_model_path": args.cls_model_path,
         "character_dict_path": args.character_dict_path,
     }
-    for name, path in need_check_file_exist.items():
-        if path and not os.path.isfile(path):
-            raise ValueError(f"{name} must be a file, but got {path}.")
+    for name, path in need_check_file.items():
+        if path:
+            if not os.path.exists(path):
+                raise ValueError(f"{name} must be a file, but {path} doesn't exist.")
+            if not os.path.isfile(path):
+                raise ValueError(f"{name} must be a file, but got a dir of {path}.")
+
+    need_check_file_or_dir = {
+        "rec_model_path": args.rec_model_path,
+    }
+    for name, path in need_check_file_or_dir.items():
+        if path:
+            if not os.path.exists(path):
+                raise ValueError(f"{name} must be a file or dir, but {path} doesn't exist.")
+            if os.path.isdir(path) and not os.listdir(path):
+                raise ValueError(f"{name} got a dir of {path}, but it is empty.")
 
     need_check_dir_not_same = {
         "input_images_dir": args.input_images_dir,
@@ -202,13 +212,6 @@ def check_and_update_args(args):
     for (name1, dir1), (name2, dir2) in itertools.combinations(need_check_dir_not_same.items(), 2):
         if (dir1 and dir2) and os.path.realpath(os.path.normcase(dir1)) == os.path.realpath(os.path.normcase(dir2)):
             raise ValueError(f"{name1} and {name2} can't be same path.")
-
-    if args.det_model_name:
-        args.det_config_path = get_config_by_name_for_model(args.det_model_name)
-    if args.cls_model_name:
-        args.cls_config_path = get_config_by_name_for_model(args.cls_model_name)
-    if args.rec_model_name:
-        args.rec_config_path = get_config_by_name_for_model(args.rec_model_name)
 
     return args
 

--- a/deploy/py_infer/src/utils/adapted/__init__.py
+++ b/deploy/py_infer/src/utils/adapted/__init__.py
@@ -1,5 +1,7 @@
 import os
 
+import yaml
+
 from .mindocr_models import MINDOCR_CONFIG_PATH, MINDOCR_MODELS
 from .mmocr_models import MMOCR_CONFIG_PATH, MMOCR_MODELS
 from .paddleocr_models import PADDLEOCR_CONFIG_PATH, PADDLEOCR_MODELS
@@ -7,12 +9,33 @@ from .paddleocr_models import PADDLEOCR_CONFIG_PATH, PADDLEOCR_MODELS
 __all__ = ["get_config_by_name_for_model"]
 
 
-def get_config_by_name_for_model(name: str):
-    if name in MINDOCR_MODELS:
-        return os.path.abspath(os.path.join(MINDOCR_CONFIG_PATH, MINDOCR_MODELS[name]))
-    elif name in PADDLEOCR_MODELS:
-        return os.path.abspath(os.path.join(PADDLEOCR_CONFIG_PATH, PADDLEOCR_MODELS[name]))
-    elif name in MMOCR_MODELS:
-        return os.path.abspath(os.path.join(MMOCR_CONFIG_PATH, MMOCR_MODELS[name]))
+def get_config_by_name_for_model(model_name_or_config: str):
+    if os.path.isfile(model_name_or_config):
+        filename = model_name_or_config
+    elif model_name_or_config in MINDOCR_MODELS:
+        filename = os.path.abspath(os.path.join(MINDOCR_CONFIG_PATH, MINDOCR_MODELS[model_name_or_config]))
+    elif model_name_or_config in PADDLEOCR_MODELS:
+        filename = os.path.abspath(os.path.join(PADDLEOCR_CONFIG_PATH, PADDLEOCR_MODELS[model_name_or_config]))
+    elif model_name_or_config in MMOCR_MODELS:
+        filename = os.path.abspath(os.path.join(MMOCR_CONFIG_PATH, MMOCR_MODELS[model_name_or_config]))
     else:
-        raise ValueError(f"The model name {name} is not supported, please check the model name.")
+        raise ValueError(
+            f"The {model_name_or_config} must be a model name or YAML config file path, "
+            "please check whether the file exists, or whether model name is in the supported models list."
+        )
+
+    with open(filename) as fp:
+        cfg = yaml.safe_load(fp)
+
+    try:
+        cfg["eval"]["dataset"]["transform_pipeline"]
+        cfg["postprocess"]
+    except KeyError:
+        preprocess_desc = "{eval: {dataset: {transform_pipeline: ...}}}"
+        postprocess_desc = "{postprocess: ...}"
+        raise ValueError(
+            f"The YAML config file {filename} must contain preprocess pipeline key {preprocess_desc} "
+            f"and postprocess key {postprocess_desc}."
+        )
+
+    return filename

--- a/docs/cn/inference/inference_tutorial_cn.md
+++ b/docs/cn/inference/inference_tutorial_cn.md
@@ -32,11 +32,11 @@ MindOCR除了支持自身训练端导出模型的推理外，还支持第三方�
   	--input_images_dir=/path/to/images \
   	--backend=lite \
   	--det_model_path=/path/to/mindir/dbnet_resnet50.mindir \
-  	--det_model_name=en_ms_det_dbnet_resnet50 \
+  	--det_model_name_or_config=../../configs/det/dbnet/db_r50_icdar15.yaml \
   	--cls_model_path=/path/to/mindir/cls_mv3.mindir \
-  	--cls_model_name=ch_pp_mobile_cls_v2.0 \
+  	--cls_model_name_or_config=ch_pp_mobile_cls_v2.0 \
   	--rec_model_path=/path/to/mindir/crnn_resnet34.mindir \
-  	--rec_model_name=en_ms_rec_crnn_resnet34 \
+  	--rec_model_name_or_config=../../configs/rec/crnn/crnn_resnet34.yaml \
   	--res_save_dir=det_cls_rec
   ```
 
@@ -55,9 +55,9 @@ MindOCR除了支持自身训练端导出模型的推理外，还支持第三方�
   	--input_images_dir=/path/to/images \
   	--backend=lite \
   	--det_model_path=/path/to/mindir/dbnet_resnet50.mindir \
-  	--det_model_name=en_ms_det_dbnet_resnet50 \
+  	--det_model_name_or_config=../../configs/det/dbnet/db_r50_icdar15.yaml \
   	--rec_model_path=/path/to/mindir/crnn_resnet34.mindir \
-  	--rec_model_name=en_ms_rec_crnn_resnet34 \
+  	--rec_model_name_or_config=../../configs/rec/crnn/crnn_resnet34.yaml \
   	--res_save_dir=det_rec
   ```
 
@@ -76,7 +76,7 @@ MindOCR除了支持自身训练端导出模型的推理外，还支持第三方�
   	--input_images_dir=/path/to/images \
   	--backend=lite \
   	--det_model_path=/path/to/mindir/dbnet_resnet50.mindir \
-  	--det_model_name=en_ms_det_dbnet_resnet50 \
+  	--det_model_name_or_config=../../configs/det/dbnet/db_r50_icdar15.yaml \
   	--res_save_dir=det
   ```
 
@@ -91,11 +91,12 @@ MindOCR除了支持自身训练端导出模型的推理外，还支持第三方�
   可以单独运行文本方向分类
 
   ```shell
+  # cls_mv3.mindir is converted from ppocr
   python infer.py \
   	--input_images_dir=/path/to/images \
   	--backend=lite \
   	--cls_model_path=/path/to/mindir/cls_mv3.mindir \
-  	--cls_model_name=ch_pp_mobile_cls_v2.0 \
+  	--cls_model_name_or_config=ch_pp_mobile_cls_v2.0 \
   	--res_save_dir=cls
   ```
 
@@ -116,7 +117,7 @@ MindOCR除了支持自身训练端导出模型的推理外，还支持第三方�
   	--input_images_dir=/path/to/images \
   	--backend=lite \
   	--rec_model_path=/path/to/mindir/crnn_resnet34.mindir \
-  	--rec_model_name=en_ms_rec_crnn_resnet34 \
+  	--rec_model_name_or_config=../../configs/rec/crnn/crnn_resnet34.yaml \
   	--res_save_dir=rec
   ```
 
@@ -131,7 +132,6 @@ MindOCR除了支持自身训练端导出模型的推理外，还支持第三方�
 #### 4.2 详细推理参数解释
 
 - 基本设置
-
 
 | 参数名称          | 类型 | 默认值   | 含义                         |
 |:-----------------|:----|:-------|:-----------------------------|
@@ -156,35 +156,29 @@ MindOCR除了支持自身训练端导出模型的推理外，还支持第三方�
 
 - 文本检测
 
-| 参数名称         | 类型 | 默认值 | 含义                   |
-|:----------------|:----|:------|:----------------------|
-| det_model_path  | str | 无    | 文本检测模型的文件路径     |
-| det_model_name  | str | 无    | 文本检测模型的名称        |
-| det_config_path | str | 无    | 文本检测模型的配置文件路径 |
+| 参数名称                  | 类型 | 默认值 | 含义                        |
+|:-------------------------|:----|:------|:---------------------------|
+| det_model_path           | str | 无    | 文本检测模型的文件路径          |
+| det_model_name_or_config | str | 无    | 文本检测模型的名称或配置文件路径 |
 
 - 文本方向分类
 
-| 参数名称         | 类型 | 默认值 | 含义                       |
-|:----------------|:----|:------|:-------------------------|
-| cls_model_path  | str | 无    | 文本方向分类模型的文件路径     |
-| cls_model_name  | str | 无    | 文本方向分类模型的名称        |
-| cls_config_path | str | 无    | 文本方向分类模型的配置文件路径 |
+| 参数名称                  | 类型 | 默认值 | 含义                           |
+|:-------------------------|:----|:------|:------------------------------|
+| cls_model_path           | str | 无    | 文本方向分类模型的文件路径          |
+| cls_model_name_or_config | str | 无    | 文本方向分类模型的名称或配置文件路径 |
 
 - 文本识别
 
-| 参数名称             | 类型 | 默认值 | 含义                                             |
-|:--------------------|:----|:------|:------------------------------------------------|
-| rec_model_path      | str | 无    | 文本检测模型的文件路径                               |
-| rec_model_name      | str | 无    | 文本检测模型的名称                                  |
-| rec_config_path     | str | 无    | 文本检测模型的配置文件路径                           |
-| character_dict_path | str | 无    | 文本识别模型对应的词典文件路径，默认值只支持数字和英文小写 |
+| 参数名称                  | 类型 | 默认值 | 含义                                             |
+|:-------------------------|:----|:------|:------------------------------------------------|
+| rec_model_path           | str | 无    | 文本识别模型的文件路径                               |
+| rec_model_name_or_config | str | 无    | 文本识别模型的名称或配置文件路径                       |
+| character_dict_path      | str | 无    | 文本识别模型对应的词典文件路径，默认值只支持数字和英文小写 |
 
 说明：
 
-1. 对于已适配的模型，`*_model_path`、`*_model_name`和`*_config_path`是对应绑定起来的，可参考[MindOCR模型支持列表](./models_list_cn.md)和[第三方模型支持列表](./models_list_thirdparty_cn.md)，
-   其中`*_model_name`和`*_config_path`都是用来确定预/后处理参数的，在使用时选择其一即可；
-
-2. 如果需要适配自己的模型，则*_config_path传入自定义的yaml文件即可，格式请参考MindOCR模型的[configs](../../../configs)或第三方模型的[configs](../../../deploy/py_infer/src/configs)。
+  `*_model_name_or_config`可以填模型名或YAML配置文件路径，可参考[MindOCR模型支持列表](./models_list_cn.md)和[第三方模型支持列表](./models_list_thirdparty_cn.md)。
 
 ### 5. 推理 (C++)
 
@@ -302,5 +296,5 @@ MindOCR除了支持自身训练端导出模型的推理外，还支持第三方�
 
 | 参数名称             | 类型 | 默认值 | 含义                                             |
 |:--------------------|:----|:------|:------------------------------------------------|
-| rec_model_path      | str | 无    | 文本检测模型的文件路径                               |
+| rec_model_path      | str | 无    | 文本识别模型的文件路径                               |
 | character_dict_path | str | 无    | 文本识别模型对应的词典文件路径，默认值只支持数字和英文小写 |

--- a/docs/en/inference/inference_tutorial_en.md
+++ b/docs/en/inference/inference_tutorial_en.md
@@ -36,11 +36,11 @@ Enter the inference directory：`cd deploy/py_infer`.
   	--input_images_dir=/path/to/images \
   	--backend=lite \
   	--det_model_path=/path/to/mindir/dbnet_resnet50.mindir \
-  	--det_model_name=en_ms_det_dbnet_resnet50 \
+  	--det_model_name_or_config=../../configs/det/dbnet/db_r50_icdar15.yaml \
   	--cls_model_path=/path/to/mindir/cls_mv3.mindir \
-  	--cls_model_name=ch_pp_mobile_cls_v2.0 \
+  	--cls_model_name_or_config=ch_pp_mobile_cls_v2.0 \
   	--rec_model_path=/path/to/mindir/crnn_resnet34.mindir \
-  	--rec_model_name=en_ms_rec_crnn_resnet34 \
+  	--rec_model_name_or_config=../../configs/rec/crnn/crnn_resnet34.yaml \
   	--res_save_dir=det_cls_rec
   ```
 
@@ -60,9 +60,9 @@ Enter the inference directory：`cd deploy/py_infer`.
   	--input_images_dir=/path/to/images \
   	--backend=lite \
   	--det_model_path=/path/to/mindir/dbnet_resnet50.mindir \
-  	--det_model_name=en_ms_det_dbnet_resnet50 \
+  	--det_model_name_or_config=../../configs/det/dbnet/db_r50_icdar15.yaml \
   	--rec_model_path=/path/to/mindir/crnn_resnet34.mindir \
-  	--rec_model_name=en_ms_rec_crnn_resnet34 \
+  	--rec_model_name_or_config=../../configs/rec/crnn/crnn_resnet34.yaml \
   	--res_save_dir=det_rec
   ```
 
@@ -81,7 +81,7 @@ Enter the inference directory：`cd deploy/py_infer`.
   	--input_images_dir=/path/to/images \
   	--backend=lite \
   	--det_model_path=/path/to/mindir/dbnet_resnet50.mindir \
-  	--det_model_name=en_ms_det_dbnet_resnet50 \
+  	--det_model_name_or_config=../../configs/det/dbnet/db_r50_icdar15.yaml \
   	--res_save_dir=det
   ```
 
@@ -96,11 +96,12 @@ Enter the inference directory：`cd deploy/py_infer`.
   Run text angle classification alone.
 
   ```shell
+  # cls_mv3.mindir is converted from ppocr
   python infer.py \
   	--input_images_dir=/path/to/images \
   	--backend=lite \
   	--cls_model_path=/path/to/mindir/cls_mv3.mindir \
-  	--cls_model_name=ch_pp_mobile_cls_v2.0 \
+  	--cls_model_name_or_config=ch_pp_mobile_cls_v2.0 \
   	--res_save_dir=cls
   ```
 
@@ -121,7 +122,7 @@ Enter the inference directory：`cd deploy/py_infer`.
   	--input_images_dir=/path/to/images \
   	--backend=lite \
   	--rec_model_path=/path/to/mindir/crnn_resnet34.mindir \
-  	--rec_model_name=en_ms_rec_crnn_resnet34 \
+  	--rec_model_name_or_config=../../configs/rec/crnn/crnn_resnet34.yaml \
   	--res_save_dir=rec
   ```
 
@@ -161,38 +162,30 @@ Enter the inference directory：`cd deploy/py_infer`.
 
 - Text detection
 
-| name            | type | default | description                    |
-|:----------------|:-----|:--------|:-------------------------------|
-| det_model_path  | str  | None    | Model path for text detection  |
-| det_model_name  | str  | None    | Model name for text detection  |
-| det_config_path | str  | None    | Config file for text detection |
+| name                     | type | default | description                                            |
+|:-------------------------|:-----|:--------|:-------------------------------------------------------|
+| det_model_path           | str  | None    | Model path for text detection                          |
+| det_model_name_or_config | str  | None    | Model name or YAML config file path for text detection |
 
 - Text angle classification
 
-| name            | type | default | description                               |
-|:----------------|:-----|:--------|:------------------------------------------|
-| cls_model_path  | str  | None    | Model path for text angle classification  |
-| cls_model_name  | str  | None    | Model name for text angle classification  |
-| cls_config_path | str  | None    | Config file for text angle classification |
+| name                     | type | default | description                                                       |
+|:-------------------------|:-----|:--------|:------------------------------------------------------------------|
+| cls_model_path           | str  | None    | Model path for text angle classification                          |
+| cls_model_name_or_config | str  | None    | Model name or YAML config file path for text angle classification |
 
 - Text recognition
 
-| name                | type | default | description                                                                 |
-|:--------------------|:-----|:--------|:----------------------------------------------------------------------------|
-| rec_model_path      | str  | None    | Model path for text recognition                                             |
-| rec_model_name      | str  | None    | Model name for text recognition                                             |
-| rec_config_path     | str  | None    | Config file for text recognition                                            |
-| character_dict_path | str  | None    | Dict file for text recognition，default only supports numbers and lowercase |
+| name                     | type | default | description                                                                 |
+|:-------------------------|:-----|:--------|:----------------------------------------------------------------------------|
+| rec_model_path           | str  | None    | Model path for text recognition                                             |
+| rec_model_name_or_config | str  | None    | Model name or YAML config file path for text recognition                    |
+| character_dict_path      | str  | None    | Dict file for text recognition，default only supports numbers and lowercase |
 
 Notes：
 
-1. For the adapted model, `*_model_path`,`*_model_name` and `*_config_path` are bounded together, please refer to
-   [MindOCR Models Support List](./models_list_en.md) and
-   [Third-Party Models Support List](./models_list_thirdparty_en.md). Both `*_model_name` and `*_config_path` are used
-   to determine pre/post processing parameters, and you can choose which one to use;
-2. If you need to adapt to your own model, `*_config_path` can simply pass in your own yaml file. Please refer to the
-   [configs](../../../configs) of the MindOCR model or the [configs](../../../deploy/py_infer/src/configs) of
-   third-party models for file format.
+`*_model_name_or_config` can be the model name or YAML config file path, please refer to [MindOCR Models Support List](./models_list_en.md) and
+[Third-Party Models Support List](./models_list_thirdparty_en.md).
 
 ### 5. Inference (C++)
 


### PR DESCRIPTION
Thank you for your contribution to the MindOCR repo.
Before submitting this PR, please make sure:

- [x] You have read the [Contributing Guidelines on pull requests](https://github.com/mindspore-lab/mindcv/blob/main/CONTRIBUTING.md)
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved terminology
- [ ] You have added unit tests

## Motivation

简化接口参数，和训练端对齐

det_model_name/det_config_path  -> det_model_name_or_config
cls_model_name/cls_config_path     -> cls_model_name_or_config
rec_model_name/rec_config_path   ->  rec_model_name_or_config

对于推理接口参数det_model_name和det_config_path，前者传入模型名，后者传入模型yaml路径，两者是关联对应的

用户在使用时二选一，用以确定预后处理参数，导致易用性低
现在合二为一改成一个参数det_model_name_or_config，和训练侧对齐，同时支持传入模型名和yaml路径

## Test Plan

(How should this PR be tested? Do you require special setup to run the test or repro the fixed bug?)

## Related Issues and PRs

(Is this PR part of a group of changes? Link the other relevant PRs and Issues here. Use https://help.github.com/en/articles/closing-issues-using-keywords for help on GitHub syntax)
