### PR TITLE
callbacks revision: allow group lr and correct the logging for resuming training

### DIFF
--- a/mindocr/utils/misc.py
+++ b/mindocr/utils/misc.py
@@ -19,3 +19,18 @@ class AverageMeter:
         self.sum += val * n
         self.count += n
         self.avg = self.sum / self.count
+
+
+def fetch_optimizer_lr(opt):
+    # print(f"Before, global step: {opt.global_step}")
+    lr = opt.learning_rate
+    if opt.dynamic_lr:
+        if opt.is_group_lr:
+            lr = ()
+            for learning_rate in opt.learning_rate:
+                cur_dynamic_lr = learning_rate(opt.global_step - 1).reshape(())
+                lr += (cur_dynamic_lr,)
+        else:
+            lr = opt.learning_rate(opt.global_step - 1).reshape(())
+    # print(f"After, global step: {opt.global_step}")
+    return lr


### PR DESCRIPTION
Thank you for your contribution to the MindOCR repo.
Before submitting this PR, please make sure:

- [x] You have read the [Contributing Guidelines on pull requests](https://github.com/mindspore-lab/mindcv/blob/main/CONTRIBUTING.md)
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved terminology
- [ ] You have added unit tests

## Motivation

When resuming training, the correct logging should be [cur_epoch/(training_epochs+start_epochs)] to avoid confusion. 

It is possible that opt.get_lr() is not a single scalar but a list of scalars. When users pass a list of dictionaries to the optimizer, for example:
```
[{  'params': group_base_params , 'lr': base_lr },   { 'params': group_small_params, 'lr': small_lr}]
```
The visualization should print each distinct lr.

## Test Plan

1. Try to resume training when start_epoch >1
2. In mindocr/optim/param_grouping.py, create a new grouping function that returns a list of dictionaries containing different lrs, for example:

```
def grouping_params(params, filter_name, learning_rate):
    base_params, small_params = [],  []
    for param in params:
        if filter_name in param.name:
            base_params.append(param)
        else:
            small_params.append(param)
    return [{  'params': base_params, 'lr': learning_rate}, 
                { 'params': small_params, 'lr': learning_rate*0.1}]
```

## Related Issues and PRs

NA
