### PR TITLE
remove axes and white margins around images in the inference mode

### DIFF
--- a/mindocr/utils/visualize.py
+++ b/mindocr/utils/visualize.py
@@ -43,6 +43,7 @@ def show_imgs(
     subplot_h = 4.8 * (figure_width / 6.4)
     figure_height = len(imgs) * subplot_h
     plt.figure(figsize=(figure_width, figure_height))
+    plt.axis('off')
     num_images = len(imgs)  # imgs.shape[0]
     for i, _img in enumerate(imgs):
         img = _img.copy()
@@ -62,7 +63,7 @@ def show_imgs(
         plt.show()
 
     if save_path is not None:
-        plt.savefig(save_path, bbox_inches="tight", dpi=300)
+        plt.savefig(save_path, bbox_inches="tight", dpi=300, pad_inches=0)
 
 
 def draw_boxes(

--- a/mindocr/utils/visualize.py
+++ b/mindocr/utils/visualize.py
@@ -43,7 +43,7 @@ def show_imgs(
     subplot_h = 4.8 * (figure_width / 6.4)
     figure_height = len(imgs) * subplot_h
     plt.figure(figsize=(figure_width, figure_height))
-    plt.axis('off')
+    plt.axis("off")
     num_images = len(imgs)  # imgs.shape[0]
     for i, _img in enumerate(imgs):
         img = _img.copy()


### PR DESCRIPTION
Thank you for your contribution to the MindOCR repo.
Before submitting this PR, please make sure:

- [x] You have read the [Contributing Guidelines on pull requests](https://github.com/mindspore-lab/mindcv/blob/main/CONTRIBUTING.md)
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved terminology
- [ ] You have added unit tests

## Motivation
Remove axes and white margins around images in the inference mode.
### Initially
![img_2_det_res](https://github.com/mindspore-lab/mindocr/assets/16683750/997b03d8-af94-4acd-99f5-9c33eca5dd55)
### Updated
![img_2_det_res_new](https://github.com/mindspore-lab/mindocr/assets/16683750/3c0c2f4b-42e3-4884-90df-bb2c18c87e0c)