### PR TITLE
Add size limits to RandomScale transform

### DIFF
--- a/mindocr/data/transforms/general_transforms.py
+++ b/mindocr/data/transforms/general_transforms.py
@@ -1,5 +1,5 @@
 import random
-from typing import List, Optional, Union
+from typing import List, Union
 
 import cv2
 import numpy as np

--- a/mindocr/data/transforms/general_transforms.py
+++ b/mindocr/data/transforms/general_transforms.py
@@ -164,12 +164,12 @@ class RandomScale:
     def __init__(
         self,
         scale_range: Union[tuple, list],
-        size_limits: Union[tuple, list] = [],
+        size_limits: Union[tuple, list] = None,
         p: float = 0.5,
         **kwargs,
     ):
         self._range = sorted(scale_range)
-        self._size_limits = sorted(size_limits)
+        self._size_limits = sorted(size_limits) if size_limits else []
         self._p = p
         assert kwargs.get("is_train", True), ValueError("RandomScale augmentation must be used for training only")
 

--- a/mindocr/data/transforms/general_transforms.py
+++ b/mindocr/data/transforms/general_transforms.py
@@ -168,8 +168,8 @@ class RandomScale:
         p: float = 0.5,
         **kwargs,
     ):
-        self._range = scale_range
-        self._size_limits = size_limits
+        self._range = sorted(scale_range)
+        self._size_limits = sorted(size_limits)
         self._p = p
         assert kwargs.get("is_train", True), ValueError("RandomScale augmentation must be used for training only")
 
@@ -183,8 +183,8 @@ class RandomScale:
             (polys)
         """
         if random.random() < self._p:
-            size = data["image"].shape[:2]
             if self._size_limits:
+                size = data["image"].shape[:2]
                 min_scale = max(self._size_limits[0] / size[0], self._size_limits[0] / size[1], self._range[0])
                 max_scale = min(self._size_limits[1] / size[0], self._size_limits[1] / size[1], self._range[1])
                 scale = np.random.uniform(min_scale, max_scale)

--- a/mindocr/data/transforms/general_transforms.py
+++ b/mindocr/data/transforms/general_transforms.py
@@ -157,7 +157,7 @@ class RandomScale:
     Randomly scales an image and its polygons in a predefined scale range.
     Args:
         scale_range: (min, max) scale range.
-        size_limits: (min_side_len, max_side_len) size limits. Default: [].
+        size_limits: (min_side_len, max_side_len) size limits. Default: None.
         p: probability of the augmentation being applied to an image.
     """
 

--- a/mindocr/data/transforms/general_transforms.py
+++ b/mindocr/data/transforms/general_transforms.py
@@ -157,7 +157,7 @@ class RandomScale:
     Randomly scales an image and its polygons in a predefined scale range.
     Args:
         scale_range: (min, max) scale range.
-        size_limits: (min_height, max_height, min_width, max_width) size limits. Default: None.
+        size_limits: (min_side_len, max_side_len) size limits. Default: None.
         p: probability of the augmentation being applied to an image.
     """
 
@@ -183,20 +183,17 @@ class RandomScale:
             (polys)
         """
         if random.random() < self._p:
-            scale = np.random.uniform(*self._range)
-
-            size = np.arr(data["image"].shape[:2])
-            size = np.round(scale * size)
-
-            if self._size_limits is not None:
-                min_len, max_len = self._size_limits
+            size = data["image"].shape[:2]
+            if self._size_limits:
+                min_scale = max(self._size_limits[0] / size[0], self._size_limits[0] / size[1], self._range[0])
+                max_scale = min(self._size_limits[1] / size[0], self._size_limits[1] / size[1], self._range[1])
+                scale = np.random.uniform(min_scale, max_scale)
             else:
-                min_len, max_len = 0, np.inf
+                scale = np.random.uniform(*self._range)
 
-            if size >= min_len and size <= max_len:
-                data["image"] = cv2.resize(data["image"], dsize=None, fx=scale, fy=scale)
-                if "polys" in data:
-                    data["polys"] *= scale
+            data["image"] = cv2.resize(data["image"], dsize=None, fx=scale, fy=scale)
+            if "polys" in data:
+                data["polys"] *= scale
 
         return data
 

--- a/mindocr/data/transforms/general_transforms.py
+++ b/mindocr/data/transforms/general_transforms.py
@@ -164,7 +164,7 @@ class RandomScale:
     def __init__(
         self,
         scale_range: Union[tuple, list],
-        size_limits: Optional[Union[tuple, list]] = None,
+        size_limits: Union[tuple, list] = None,
         p: float = 0.5,
         **kwargs,
     ):
@@ -185,15 +185,15 @@ class RandomScale:
         if random.random() < self._p:
             scale = np.random.uniform(*self._range)
 
-            H, W, _ = data["image"].shape
-            H_scaled, W_scaled = int(scale * H), int(scale * W)
+            size = np.arr(data["image"].shape[:2])
+            size = np.round(scale * size)
 
             if self._size_limits is not None:
-                H_min, H_max, W_min, W_max = self._size_limits
+                min_len, max_len = self._size_limits
             else:
-                H_min, H_max, W_min, W_max = 0, float("inf"), 0, float("inf")
+                min_len, max_len = 0, np.inf
 
-            if H_min <= H_scaled <= H_max and W_min <= W_scaled <= W_max:
+            if size >= min_len and size <= max_len:
                 data["image"] = cv2.resize(data["image"], dsize=None, fx=scale, fy=scale)
                 if "polys" in data:
                     data["polys"] *= scale

--- a/mindocr/data/transforms/general_transforms.py
+++ b/mindocr/data/transforms/general_transforms.py
@@ -157,14 +157,14 @@ class RandomScale:
     Randomly scales an image and its polygons in a predefined scale range.
     Args:
         scale_range: (min, max) scale range.
-        size_limits: (min_side_len, max_side_len) size limits. Default: None.
+        size_limits: (min_side_len, max_side_len) size limits. Default: [].
         p: probability of the augmentation being applied to an image.
     """
 
     def __init__(
         self,
         scale_range: Union[tuple, list],
-        size_limits: Union[tuple, list] = None,
+        size_limits: Union[tuple, list] = [],
         p: float = 0.5,
         **kwargs,
     ):


### PR DESCRIPTION
Thank you for your contribution to the MindOCR repo.
Before submitting this PR, please make sure:

- [x] You have read the [Contributing Guidelines on pull requests](https://github.com/mindspore-lab/mindcv/blob/main/CONTRIBUTING.md)
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved terminology
- [ ] You have added unit tests

## Motivation

During training, the RandomScale transform randomly scaled the images in the datasets; however, in some datasets, there are mixtures of small and big images, which, when scaled randomly, may lead to extremely small or extremely large images.

Therefore, this PR implements the logic of taking the minimum and maximum side lengths (`side_limits`) as arguments and then using them to calculate the scaling factor, so the randomly scaled images always stay within the specified reasonable limits.

## Test Plan

(How should this PR be tested? Do you require special setup to run the test or repro the fixed bug?)

## Related Issues and PRs

(Is this PR part of a group of changes? Link the other relevant PRs and Issues here. Use https://help.github.com/en/articles/closing-issues-using-keywords for help on GitHub syntax)
