### PR TITLE
Fix error during loss reduce in callback

### DIFF
--- a/mindocr/utils/callbacks.py
+++ b/mindocr/utils/callbacks.py
@@ -9,7 +9,7 @@ from mindspore.train.callback._callback import Callback, _handle_loss
 from .checkpoint import CheckpointManager
 from .evaluator import Evaluator
 from .logger import Logger
-from .misc import AverageMeter, fetch_optimizer_lr
+from .misc import AllReduce, AverageMeter, fetch_optimizer_lr
 from .recorder import PerfRecorder
 
 __all__ = ["EvalSaveCallback"]
@@ -95,8 +95,8 @@ class EvalSaveCallback(Callback):
 
         self._loss_avg_meter = AverageMeter()
 
-        self._reduce_sum = ms.ops.AllReduce()
         self._device_num = device_num
+        self._reduce = AllReduce(device_num=self._device_num)
         # lamda expression is not supported in jit
         self._loss_reduce = self._reduce if device_num is not None else lambda x: x
 
@@ -109,9 +109,6 @@ class EvalSaveCallback(Callback):
                 prefer_low_perf=(self.main_indicator == "train_loss"),
             )
         self.start_epoch = start_epoch
-
-    def _reduce(self, x):
-        return self._reduce_sum(x) / self._device_num  # average value across all devices
 
     def on_train_step_end(self, run_context):
         """

--- a/mindocr/utils/misc.py
+++ b/mindocr/utils/misc.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from packaging import version
 
 import mindspore as ms
@@ -42,14 +44,18 @@ def fetch_optimizer_lr(opt):
 
 
 class AllReduce(nn.Cell):
-    def __init__(self, reduce: str = "mean", device_num: int = 1):
+    def __init__(self, reduce: str = "mean", device_num: Optional[int] = None) -> None:
         super().__init__()
         if reduce == "mean":
             self.average = True
         else:
             self.average = False
 
-        self.device_num = device_num
+        if device_num is None:
+            self.device_num = 1
+        else:
+            self.device_num = device_num
+
         self.all_reduce = ops.AllReduce()
 
     def construct(self, x: Tensor) -> Tensor:

--- a/mindocr/utils/misc.py
+++ b/mindocr/utils/misc.py
@@ -46,10 +46,7 @@ def fetch_optimizer_lr(opt):
 class AllReduce(nn.Cell):
     def __init__(self, reduce: str = "mean", device_num: Optional[int] = None) -> None:
         super().__init__()
-        if reduce == "mean":
-            self.average = True
-        else:
-            self.average = False
+        self.average = reduce == "mean"
 
         if device_num is None:
             self.device_num = 1


### PR DESCRIPTION
Recent change on callback.py cause `RuntimeError: Couldn't get correct hccl hcom with group hccl_world_group` in MindSpore 1.10 in OpenI. Seems ops.ReduceSum must be compiled first. This is a fix.

Meanwhile this change give a better loss value report once the loss output is fp16.

Thank you for your contribution to the MindOCR repo.
Before submitting this PR, please make sure:

- [ ] You have read the [Contributing Guidelines on pull requests](https://github.com/mindspore-lab/mindcv/blob/main/CONTRIBUTING.md)
- [ ] Your code builds clean without any errors or warnings
- [ ] You are using approved terminology
- [ ] You have added unit tests

## Motivation

(Write your motivation for proposed changes here.)

## Test Plan

(How should this PR be tested? Do you require special setup to run the test or repro the fixed bug?)

## Related Issues and PRs

(Is this PR part of a group of changes? Link the other relevant PRs and Issues here. Use https://help.github.com/en/articles/closing-issues-using-keywords for help on GitHub syntax)
