### PR TITLE
Move save config before training start log

### DIFF
--- a/tools/train.py
+++ b/tools/train.py
@@ -198,8 +198,7 @@ def main(cfg):
     # save args used for training
     if rank_id in [None, 0]:
         with open(os.path.join(cfg.train.ckpt_save_dir, "args.yaml"), "w") as f:
-            args_text = yaml.safe_dump(cfg.to_dict(), default_flow_style=False, sort_keys=False)
-            f.write(args_text)
+            yaml.safe_dump(cfg.to_dict(), stream=f, default_flow_style=False, sort_keys=False)
 
     # log
     num_devices = device_num if device_num is not None else 1

--- a/tools/train.py
+++ b/tools/train.py
@@ -195,6 +195,12 @@ def main(cfg):
         start_epoch=start_epoch,
     )
 
+    # save args used for training
+    if rank_id in [None, 0]:
+        with open(os.path.join(cfg.train.ckpt_save_dir, "args.yaml"), "w") as f:
+            args_text = yaml.safe_dump(cfg.to_dict(), default_flow_style=False, sort_keys=False)
+            f.write(args_text)
+
     # log
     num_devices = device_num if device_num is not None else 1
     global_batch_size = cfg.train.loader.batch_size * num_devices * gradient_accumulation_steps
@@ -228,12 +234,6 @@ def main(cfg):
         f"{info_seg}\n"
         f"\nStart training... (The first epoch takes longer, please wait...)\n"
     )
-
-    # save args used for training
-    if rank_id in [None, 0]:
-        with open(os.path.join(cfg.train.ckpt_save_dir, "args.yaml"), "w") as f:
-            args_text = yaml.safe_dump(cfg.to_dict(), default_flow_style=False, sort_keys=False)
-            f.write(args_text)
 
     # training
     model = ms.Model(train_net)


### PR DESCRIPTION
Sometimes the saving config takes very long time (especially for large dataset and thus the optimizer.lr is very long) and may even stuck. The log saying the training is start but actually it is not. So suggested to move the config saving before logging of "training start"

Thank you for your contribution to the MindOCR repo.
Before submitting this PR, please make sure:

- [ ] You have read the [Contributing Guidelines on pull requests](https://github.com/mindspore-lab/mindcv/blob/main/CONTRIBUTING.md)
- [ ] Your code builds clean without any errors or warnings
- [ ] You are using approved terminology
- [ ] You have added unit tests

## Motivation

(Write your motivation for proposed changes here.)

## Test Plan

(How should this PR be tested? Do you require special setup to run the test or repro the fixed bug?)

## Related Issues and PRs

(Is this PR part of a group of changes? Link the other relevant PRs and Issues here. Use https://help.github.com/en/articles/closing-issues-using-keywords for help on GitHub syntax)
