### PR TITLE
Replace deprecated ResizeBilinear for EAST

### DIFF
--- a/mindocr/models/necks/fpn.py
+++ b/mindocr/models/necks/fpn.py
@@ -280,17 +280,17 @@ class EASTFPN(nn.Cell):
     def construct(self, features):
         f1, f2, f3, f4 = features
 
-        out = ops.ResizeBilinear(f3.shape[2:], True)(f4)
+        out = ops.ResizeBilinearV2(True)(f4, f3.shape[2:])
         out = self.concat((out, f3))
         out = self.relu1(self.bn1(self.conv1(out)))
         out = self.relu2(self.bn2(self.conv2(out)))
 
-        out = ops.ResizeBilinear(f2.shape[2:], True)(out)
+        out = ops.ResizeBilinearV2(True)(out, f2.shape[2:])
         out = self.concat((out, f2))
         out = self.relu3(self.bn3(self.conv3(out)))
         out = self.relu4(self.bn4(self.conv4(out)))
 
-        out = ops.ResizeBilinear(f1.shape[2:], True)(out)
+        out = ops.ResizeBilinearV2(True)(out, f1.shape[2:])
         out = self.concat((out, f1))
         out = self.relu5(self.bn5(self.conv5(out)))
         out = self.relu6(self.bn6(self.conv6(out)))


### PR DESCRIPTION
Thank you for your contribution to the MindOCR repo.
Before submitting this PR, please make sure:

- [x] You have read the [Contributing Guidelines on pull requests](https://github.com/mindspore-lab/mindcv/blob/main/CONTRIBUTING.md)
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved terminology
- [ ] You have added unit tests

## Motivation

Change this API to accept dynamic shape input

## Test Plan

Already tested and model results are the same.

## Related Issues and PRs

(Is this PR part of a group of changes? Link the other relevant PRs and Issues here. Use https://help.github.com/en/articles/closing-issues-using-keywords for help on GitHub syntax)
