### PR TITLE
Move ResizeBilinearV2 definition into __init__ for EASTFPN

### DIFF
--- a/mindocr/models/necks/fpn.py
+++ b/mindocr/models/necks/fpn.py
@@ -226,6 +226,7 @@ class EASTFPN(nn.Cell):
         super(EASTFPN, self).__init__()
         self.in_channels = in_channels[::-1]  # self.in_channels: [2048, 1024, 512, 256]
         self.out_channels = out_channels
+        self.resize = ops.ResizeBilinearV2(True)
         self.conv1 = nn.Conv2d(self.in_channels[0] + self.in_channels[1], self.in_channels[0] // 4, 1, has_bias=True)
         self.bn1 = nn.BatchNorm2d(self.in_channels[0] // 4)
         self.relu1 = nn.ReLU()
@@ -280,17 +281,17 @@ class EASTFPN(nn.Cell):
     def construct(self, features):
         f1, f2, f3, f4 = features
 
-        out = ops.ResizeBilinearV2(True)(f4, f3.shape[2:])
+        out = self.resize(f4, f3.shape[2:])
         out = self.concat((out, f3))
         out = self.relu1(self.bn1(self.conv1(out)))
         out = self.relu2(self.bn2(self.conv2(out)))
 
-        out = ops.ResizeBilinearV2(True)(out, f2.shape[2:])
+        out = self.resize(out, f2.shape[2:])
         out = self.concat((out, f2))
         out = self.relu3(self.bn3(self.conv3(out)))
         out = self.relu4(self.bn4(self.conv4(out)))
 
-        out = ops.ResizeBilinearV2(True)(out, f1.shape[2:])
+        out = self.resize(out, f1.shape[2:])
         out = self.concat((out, f1))
         out = self.relu5(self.bn5(self.conv5(out)))
         out = self.relu6(self.bn6(self.conv6(out)))


### PR DESCRIPTION
Thank you for your contribution to the MindOCR repo.
Before submitting this PR, please make sure:

- [x] You have read the [Contributing Guidelines on pull requests](https://github.com/mindspore-lab/mindcv/blob/main/CONTRIBUTING.md)
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved terminology
- [ ] You have added unit tests

## Motivation

Adopt Rustam's suggestion from #479 

## Test Plan

Already tested the training and inference for EAST

## Related Issues and PRs

(Is this PR part of a group of changes? Link the other relevant PRs and Issues here. Use https://help.github.com/en/articles/closing-issues-using-keywords for help on GitHub syntax)
