### PR TITLE
fix empty polygons processing

### DIFF
--- a/mindocr/data/transforms/det_transforms.py
+++ b/mindocr/data/transforms/det_transforms.py
@@ -122,7 +122,8 @@ class RandomCropWithBBox:
             data["image"], (*tuple((0, cs - ds) for cs, ds in zip(self._crop_size, data["image"].shape[:2])), (0, 0))
         )
 
-        data["polys"] = (data["polys"] - start[::-1]) * scale
+        if len(data["polys"]):
+            data["polys"] = (data["polys"] - start[::-1]) * scale
 
         return data
 
@@ -509,7 +510,7 @@ class DetResize:
         # For evaluation, we should not change the GT polygons.
         # The metric with input of GT polygons and predicted polygons must be computed in the original image space
         # for consistent comparison.
-        if "polys" in data and self.is_train:
+        if "polys" in data and len(data["polys"]) and self.is_train:
             data["polys"][:, :, 0] = data["polys"][:, :, 0] * scale_w
             data["polys"][:, :, 1] = data["polys"][:, :, 1] * scale_h
 

--- a/mindocr/data/transforms/general_transforms.py
+++ b/mindocr/data/transforms/general_transforms.py
@@ -249,7 +249,7 @@ class RandomRotate:
 
             data["image"] = cv2.warpAffine(data["image"], mat, (w, h))
 
-            if "polys" in data:
+            if "polys" in data and len(data["polys"]):
                 data["polys"] = cv2.transform(data["polys"], mat)
 
         return data
@@ -269,7 +269,7 @@ class RandomHorizontalFlip:
         if random.random() < self._p:
             data["image"] = cv2.flip(data["image"], 1)
 
-            if "polys" in data:
+            if "polys" in data and len(data["polys"]):
                 mat = np.float32([[-1, 0, data["image"].shape[1] - 1], [0, 1, 0]])
                 data["polys"] = cv2.transform(data["polys"], mat)
                 # TODO: assign a new starting point located in the top left


### PR DESCRIPTION
Thank you for your contribution to the MindOCR repo.
Before submitting this PR, please make sure:

- [x] You have read the [Contributing Guidelines on pull requests](https://github.com/mindspore-lab/mindcv/blob/main/CONTRIBUTING.md)
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved terminology
- [ ] You have added unit tests

## Motivation
PR #460 added support of samples with no text instances (as in test sets of some datasets). This PR fixes some remaining bugs in the data transformation pipeline: it checks whether text instances are present in a sample before applying operations that don't support empty arrays (e.g. `cv2.transform()`).