### PR TITLE
fix visionlan head for multiple inputs

### DIFF
--- a/mindocr/models/heads/rec_visionlan_head.py
+++ b/mindocr/models/heads/rec_visionlan_head.py
@@ -380,7 +380,7 @@ class VisionLANHead(nn.Cell):
     def construct(self, features, targets=None):
         # MLM + VRM
         if self.training:
-            label_pos = targets
+            label_pos = targets[0]  # targets is a list of inputs to the head
             text_pre, test_rem, text_mas, mask_map = self.MLM_VRM(features,
                                                                   label_pos,
                                                                   self.training_step,

--- a/mindocr/postprocess/rec_postprocess.py
+++ b/mindocr/postprocess/rec_postprocess.py
@@ -189,7 +189,7 @@ class VisionLANPostProcess(RecCTCLabelDecode):
 
     def __call__(self, preds, *args, **kwargs):
         if isinstance(preds, Tensor):  # eval mode
-            text_pre = preds.numpy()  # (max_len, b, 37)) before the softmax function
+            text_pre = preds.asnumpy()  # (max_len, b, 37)) before the softmax function
             b = text_pre.shape[1]
             lenText = self.max_text_length
             nsteps = self.max_text_length

--- a/tests/ut/test_models.py
+++ b/tests/ut/test_models.py
@@ -20,6 +20,7 @@ all_yamls = [
     "configs/rec/master/master_resnet31.yaml",
     "configs/rec/rare/rare_resnet34.yaml",
     "configs/rec/svtr/svtr_tiny.yaml",
+    "configs/rec/visionlan/visionlan_resnet45_LF_1.yaml",
     "configs/cls/mobilenetv3/cls_mv3.yaml",
 ]
 print("All config yamls: ", all_yamls)


### PR DESCRIPTION
Because of #444  , the BaseModel.construct() has been changed, I also need to change visionlan head to make it compatible.