### PR TITLE
fix output file names for prediction pipeline

### DIFF
--- a/tools/export.py
+++ b/tools/export.py
@@ -51,7 +51,7 @@ def export(name_or_config, data_shape, local_ckpt_path, save_dir):
             cfg = yaml.safe_load(f)
             model_cfg = cfg["model"]
             amp_level = cfg["system"].get("amp_level_infer", "O0")
-        name = os.path.basename(name_or_config).split(".")[0]
+        name = os.path.basename(name_or_config).rsplit(".", 1)[0]
         assert (
             local_ckpt_path
         ), "Checkpoint path must be specified if using YAML config file to define model architecture. \

--- a/tools/infer/text/predict_det.py
+++ b/tools/infer/text/predict_det.py
@@ -98,7 +98,7 @@ class TextDetector(object):
         """
         # preprocess
         data = self.preprocess(img_or_path)
-        fn = os.path.basename(data.get("img_path", "input.png")).split(".")[0]
+        fn = os.path.basename(data.get("img_path", "input.png")).rsplit(".", 1)[0]
         if do_visualize and self.visualize_preprocess:
             # show_imgs([data['image_ori']], is_bgr_img=False, title='det: '+ data['img_path'])
             # TODO: saving images increase inference time.

--- a/tools/infer/text/predict_rec.py
+++ b/tools/infer/text/predict_rec.py
@@ -162,7 +162,7 @@ class TextRecognizer(object):
                 data = self.preprocess(img_or_path_list[j])
                 img_batch.append(data["image"])
                 if do_visualize:
-                    fn = os.path.basename(data.get("img_path", f"crop_{j}.png")).split(".")[0]
+                    fn = os.path.basename(data.get("img_path", f"crop_{j}.png")).rsplit(".", 1)[0]
                     show_imgs(
                         [data["image"]],
                         title=fn + "_rec_preprocessed",

--- a/tools/infer/text/predict_rec.py
+++ b/tools/infer/text/predict_rec.py
@@ -206,7 +206,7 @@ class TextRecognizer(object):
         # visualize preprocess result
         if do_visualize:
             # show_imgs([data['image_ori']], is_bgr_img=False, title=f'origin_{i}')
-            fn = os.path.basename(data.get("img_path", f"crop_{crop_idx}.png")).split(".")[0]
+            fn = os.path.basename(data.get("img_path", f"crop_{crop_idx}.png")).rsplit(".", 1)[0]
             show_imgs(
                 [data["image"]],
                 title=fn + "_rec_preprocessed",

--- a/tools/infer/text/predict_system.py
+++ b/tools/infer/text/predict_system.py
@@ -65,7 +65,7 @@ class TextSystem(object):
         assert isinstance(img_or_path, str) or isinstance(
             img_or_path, np.ndarray
         ), "Input must be string of path to the image or numpy array of the image rgb values."
-        fn = os.path.basename(img_or_path).split(".")[0] if isinstance(img_or_path, str) else "img"
+        fn = os.path.basename(img_or_path).rsplit(".", 1)[0] if isinstance(img_or_path, str) else "img"
 
         time_profile = {}
         start = time()


### PR DESCRIPTION
Thank you for your contribution to the MindOCR repo.
Before submitting this PR, please make sure:

- [x] You have read the [Contributing Guidelines on pull requests](https://github.com/mindspore-lab/mindcv/blob/main/CONTRIBUTING.md)
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved terminology
- [ ] You have added unit tests

## Motivation
Some datasets have `category.name.jpg` file naming. Current prediction pipeline splits names by the first dot and generates images with `category.jpg` names, thus overwriting them. This PR solves this problem and keeps the visualized image names as `category.name.jpg`.