### PR TITLE
Update Master Model

### DIFF
--- a/configs/rec/master/README.md
+++ b/configs/rec/master/README.md
@@ -37,7 +37,7 @@ According to our experiments, the evaluation results on public benchmark dataset
 
 | **Model** | **Context** | **Avg Accuracy** | **Train T.** | **FPS** | **Recipe** | **Download** |
 | :-----: | :-----------: | :--------------: | :----------: | :--------: | :--------: |:----------: |
-| Master-Resnet31  | D910x8-MS1.10-G | 90.20%  | 3721 s/epoch   | 4632  | [yaml](https://github.com/mindspore-lab/mindocr/blob/main/configs/rec/master/master_resnet31.yaml) | [ckpt](https://download.mindspore.cn/toolkits/mindocr/master/master_resnet31-7565c75f.ckpt) \| [mindir](https://download.mindspore.cn/toolkits/mindocr/master/master_resnet31_ascend-7565c75f-65015efe.mindir) |
+| Master-Resnet31  | D910x4-MS1.10-G | 90.37%  | 6356 s/epoch   | 2741  | [yaml](https://github.com/mindspore-lab/mindocr/blob/main/configs/rec/master/master_resnet31.yaml) | [ckpt](https://download.mindspore.cn/toolkits/mindocr/master/master_resnet31-e7bfbc97.ckpt) \| [mindir](https://download.mindspore.cn/toolkits/mindocr/master/master_resnet31_ascend-e7bfbc97-b724ed55.mindir) |
 </div>
 
 <details open markdown>
@@ -46,12 +46,12 @@ According to our experiments, the evaluation results on public benchmark dataset
 
   | **Model** | **IC03_860** | **IC03_867** | **IC13_857** | **IC13_1015** | **IC15_1811** | **IC15_2077** | **IIIT5k_3000** | **SVT** | **SVTP** | **CUTE80** | **Average** |
   | :------: | :------: | :------: | :------: | :------: | :------: | :------: | :------: | :------: | :------: | :------: | :------: |
-  | Master-ResNet31| 95.81% | 95.73%  | 96.97% | 95.57% | 81.83% | 78.29% | 96.33% | 90.57% | 82.33% | 88.54% | 90.20% |
+  | Master-ResNet31| 95.58% | 95.15%  | 96.85% | 95.17% | 81.94% | 78.48% | 95.56% | 90.88% | 84.19% | 89.93% | 90.37% |
   </div>
 </details>
 
 **Notes:**
-- Context: Training context denoted as {device}x{pieces}-{MS mode}, where mindspore mode can be G-graph mode or F-pynative mode with ms function. For example, D910x8-MS1.10-G is for training on 8 pieces of Ascend 910 NPU using graph mode based on Minspore version 1.10.
+- Context: Training context denoted as {device}x{pieces}-{MS mode}, where mindspore mode can be G-graph mode or F-pynative mode with ms function. For example, D910x4-MS1.10-G is for training on 4 pieces of Ascend 910 NPU using graph mode based on Minspore version 1.10.
 - To reproduce the result on other contexts, please ensure the global batch size is the same.
 - The models are trained from scratch without any pre-training. For more dataset details of training and evaluation, please refer to [Dataset Download & Dataset Usage](#312-dataset-download) section.
 - The input Shapes of MindIR of MASTER is (1, 3, 48, 160).
@@ -310,7 +310,7 @@ It is easy to reproduce the reported results with the pre-defined training recip
 
 ```shell
 # distributed training on multiple GPU/Ascend devices
-mpirun --allow-run-as-root -n 8 python tools/train.py --config configs/rec/master/master_resnet31.yaml
+mpirun --allow-run-as-root -n 4 python tools/train.py --config configs/rec/master/master_resnet31.yaml
 ```
 
 

--- a/configs/rec/master/README_CN.md
+++ b/configs/rec/master/README_CN.md
@@ -38,7 +38,7 @@ Table Format:
 
 | **模型** | **环境配置** | **平均准确率** | **训练时间** | **FPS** | **配置文件** | **模型权重下载** |
 | :-----: | :-----:  | :-----: | :-----: | :-----: |:--------: | :-----: |
-| Master-Resnet31     | D910x4-MS1.10-G | 90.20%    | 3721 s/epoch        | 4632 | [yaml](https://github.com/mindspore-lab/mindocr/blob/main/configs/rec/master/master_resnet31.yaml) | [ckpt](https://download.mindspore.cn/toolkits/mindocr/master/master_resnet31-7565c75f.ckpt) \| [mindir](https://download.mindspore.cn/toolkits/mindocr/master/master_resnet31_ascend-7565c75f-65015efe.mindir) |
+| Master-Resnet31     | D910x4-MS1.10-G | 90.37%    | 6356 s/epoch        | 2741 | [yaml](https://github.com/mindspore-lab/mindocr/blob/main/configs/rec/master/master_resnet31.yaml) | [ckpt](https://download.mindspore.cn/toolkits/mindocr/master/master_resnet31-e7bfbc97.ckpt) \| [mindir](https://download.mindspore.cn/toolkits/mindocr/master/master_resnet31_ascend-e7bfbc97-b724ed55.mindir) |
 </div>
 
 <details open markdown>
@@ -47,12 +47,12 @@ Table Format:
 
   | **模型** | **IC03_860** | **IC03_867** | **IC13_857** | **IC13_1015** | **IC15_1811** | **IC15_2077** | **IIIT5k_3000** | **SVT** | **SVTP** | **CUTE80** | **平均准确率** |
   | :------: | :------: | :------: | :------: | :------: | :------: | :------: | :------: | :------: | :------: | :------: | :------: |
-  | Master-ResNet31| 95.81% | 95.73%  | 96.97% | 95.57% | 81.83% | 78.29% | 96.33% | 90.57% | 82.33% | 88.54% | 90.20% |
+  | Master-ResNet31| 95.58% | 95.15%  | 96.85% | 95.17% | 81.94% | 78.48% | 95.56% | 90.88% | 84.19% | 89.93% | 90.37% |
   </div>
 </details>
 
 **注意:**
-- 环境配置：训练的环境配置表示为 {处理器}x{处理器数量}-{MS模式}，其中 Mindspore 模式可以是 G-graph 模式或 F-pynative 模式。例如，D910x8-MS1.10-G 用于使用图形模式在8张昇腾910 NPU上依赖Mindspore1.10版本进行训练。
+- 环境配置：训练的环境配置表示为 {处理器}x{处理器数量}-{MS模式}，其中 Mindspore 模式可以是 G-graph 模式或 F-pynative 模式。例如，D910x8-MS1.10-G 用于使用图形模式在4张昇腾910 NPU上依赖Mindspore1.10版本进行训练。
 - 如需在其他环境配置重现训练结果，请确保全局批量大小与原配置文件保持一致。
 - 模型都是从头开始训练的，无需任何预训练。关于训练和测试数据集的详细介绍，请参考[数据集下载及使用](#312-数据集下载)章节。
 - Master的MindIR导出时的输入Shape均为(1, 3, 48, 160)。
@@ -309,7 +309,7 @@ eval:
 
 ```shell
 # 在多个 GPU/Ascend 设备上进行分布式训练
-mpirun --allow-run-as-root -n 8 python tools/train.py --config configs/rec/master/master_resnet31.yaml
+mpirun --allow-run-as-root -n 4 python tools/train.py --config configs/rec/master/master_resnet31.yaml
 ```
 
 

--- a/configs/rec/master/master_resnet31.yaml
+++ b/configs/rec/master/master_resnet31.yaml
@@ -55,8 +55,8 @@ loss:
 
 scheduler:
   scheduler: warmup_cosine_decay
-  min_lr: 0.00001
-  lr: 0.001
+  min_lr: 0.000005
+  lr: 0.0005
   num_epochs: 20
   warmup_epochs: 1
   decay_epochs: 19
@@ -113,7 +113,7 @@ train:
     batch_size: *batch_size
     drop_remainder: True
     max_rowsize: 12
-    num_workers: 2
+    num_workers: 1
 
 eval:
   ckpt_load_path: ./tmp_rec/best.ckpt
@@ -154,4 +154,4 @@ eval:
     batch_size: 64
     drop_remainder: False
     max_rowsize: 12
-    num_workers: 2
+    num_workers: 1

--- a/configs/rec/master/master_resnet31.yaml
+++ b/configs/rec/master/master_resnet31.yaml
@@ -55,8 +55,8 @@ loss:
 
 scheduler:
   scheduler: warmup_cosine_decay
-  min_lr: 0.000005
-  lr: 0.0005
+  min_lr: 5.0e-6
+  lr: 5.0e-4
   num_epochs: 20
   warmup_epochs: 1
   decay_epochs: 19

--- a/docs/cn/mkdocs/modelzoo_training.md
+++ b/docs/cn/mkdocs/modelzoo_training.md
@@ -24,7 +24,7 @@
 | crnn_resnet34_vd   | IC03,13,15,IIIT,etc | 64 | 8 | 84.45 | 76.48 | 6694.84 | O3 |  [mindocr_crnn](https://github.com/mindspore-lab/mindocr/tree/main/configs/rec/crnn)   |
 | rare_resnet34_vd   | IC03,13,15,IIIT,etc | 512 | 4 | 85.19 | 449 | 4561 | O2 |  [mindocr_rare](https://github.com/mindspore-lab/mindocr/tree/main/configs/rec/rare)   |
 | visionlan_resnet45| IC03,13,15,IIIT,etc | 192| 4 | 90.61 | 417 | 1840 | O2 | [mindocr_visionlan](https://github.com/mindspore-lab/mindocr/blob/main/configs/rec/visionlan) |
-| master_resnet31   | IC03,13,15,IIIT,etc | 512 | 4 | 90.37 | 747 | 2741 | O2 |  [mindocr_rare](https://github.com/mindspore-lab/mindocr/tree/main/configs/rec/master)   |
+| master_resnet31   | IC03,13,15,IIIT,etc | 512 | 4 | 90.37 | 747 | 2741 | O2 |  [mindocr_master](https://github.com/mindspore-lab/mindocr/tree/main/configs/rec/master)   |
 | robustscanner_resnet31 | IC13,15,IIIT,SVT,etc | 256 | 4 | 87.86 |   825   |   310   | O0  |           [mindocr_robustscanner](https://github.com/mindspore-lab/mindocr/blob/main/configs/rec/robustscanner)            |
 
 ### 文本方向分类

--- a/docs/cn/mkdocs/modelzoo_training.md
+++ b/docs/cn/mkdocs/modelzoo_training.md
@@ -19,11 +19,12 @@
 
 | model  |dataset |bs | cards | acc | ms/step | fps | amp | config |
 :-:     |   :-:   | :-: | :-: |  :-:   |  :-:    | :-:  |  :-: |  :-:    |
-| svtr_tiny          | IC03,13,15,IIIT,etc | 512 | 4 | 89.02 | 690 | 2968 | O2 |  [mindocr_svtr](https://github.com/mindspore-lab/mindocr/tree/main/configs/rec/svtr)   |
+| svtr_tiny          | IC03,13,15,IIIT,etc | 512 | 4 | 90.23 | 459 | 4560 | O2 |  [mindocr_svtr](https://github.com/mindspore-lab/mindocr/tree/main/configs/rec/svtr)   |
 | crnn_vgg7          | IC03,13,15,IIIT,etc | 16 | 8 | 82.03 | 22.06 | 5802.71 | O3 |  [mindocr_crnn](https://github.com/mindspore-lab/mindocr/tree/main/configs/rec/crnn)   |
 | crnn_resnet34_vd   | IC03,13,15,IIIT,etc | 64 | 8 | 84.45 | 76.48 | 6694.84 | O3 |  [mindocr_crnn](https://github.com/mindspore-lab/mindocr/tree/main/configs/rec/crnn)   |
 | rare_resnet34_vd   | IC03,13,15,IIIT,etc | 512 | 4 | 85.19 | 449 | 4561 | O2 |  [mindocr_rare](https://github.com/mindspore-lab/mindocr/tree/main/configs/rec/rare)   |
 | visionlan_resnet45| IC03,13,15,IIIT,etc | 192| 4 | 90.61 | 417 | 1840 | O2 | [mindocr_visionlan](https://github.com/mindspore-lab/mindocr/blob/main/configs/rec/visionlan) |
+| master_resnet31   | IC03,13,15,IIIT,etc | 512 | 4 | 90.37 | 747 | 2741 | O2 |  [mindocr_rare](https://github.com/mindspore-lab/mindocr/tree/main/configs/rec/master)   |
 | robustscanner_resnet31 | IC13,15,IIIT,SVT,etc | 256 | 4 | 87.86 |   825   |   310   | O0  |           [mindocr_robustscanner](https://github.com/mindspore-lab/mindocr/blob/main/configs/rec/robustscanner)            |
 
 ### 文本方向分类

--- a/docs/en/mkdocs/modelzoo_training.md
+++ b/docs/en/mkdocs/modelzoo_training.md
@@ -19,11 +19,12 @@
 
 | model  |dataset |bs | cards | acc | ms/step | fps | amp | config |
 :-:     |   :-:   | :-: | :-: |  :-:   |  :-:    | :-:  |  :-: |  :-:    |
-| svtr_tiny          | IC03,13,15,IIIT,etc | 512 | 4 | 89.02 | 690 | 2968 | O2 |  [mindocr_svtr](https://github.com/mindspore-lab/mindocr/tree/main/configs/rec/svtr)   |
+| svtr_tiny          | IC03,13,15,IIIT,etc | 512 | 4 | 90.23 | 459 | 4560 | O2 |  [mindocr_svtr](https://github.com/mindspore-lab/mindocr/tree/main/configs/rec/svtr)   |
 | crnn_vgg7          | IC03,13,15,IIIT,etc | 16 | 8 | 82.03 | 22.06 | 5802.71 | O3 |  [mindocr_crnn](https://github.com/mindspore-lab/mindocr/tree/main/configs/rec/crnn)   |
 | crnn_resnet34_vd   | IC03,13,15,IIIT,etc | 64 | 8 | 84.45 | 76.48 | 6694.84 | O3 |  [mindocr_crnn](https://github.com/mindspore-lab/mindocr/tree/main/configs/rec/crnn)   |
 | rare_resnet34_vd   | IC03,13,15,IIIT,etc | 512 | 4 | 85.19 | 449 | 4561 | O2 |  [mindocr_rare](https://github.com/mindspore-lab/mindocr/tree/main/configs/rec/rare)   |
 | visionlan_resnet45| IC03,13,15,IIIT,etc | 192| 4 | 90.61 | 417 | 1840 | O2 | [mindocr_visionlan](https://github.com/mindspore-lab/mindocr/blob/main/configs/rec/visionlan) |
+| master_resnet31   | IC03,13,15,IIIT,etc | 512 | 4 | 90.37 | 747 | 2741 | O2 |  [mindocr_rare](https://github.com/mindspore-lab/mindocr/tree/main/configs/rec/master)   |
 | robustscanner_resnet31 | IC13,15,IIIT,SVT,etc | 256 | 4 | 87.86 |   825   |   310   | O0  |           [mindocr_robustscanner](https://github.com/mindspore-lab/mindocr/blob/main/configs/rec/robustscanner)            |
 
 ### Text Direction Classification

--- a/docs/en/mkdocs/modelzoo_training.md
+++ b/docs/en/mkdocs/modelzoo_training.md
@@ -24,7 +24,7 @@
 | crnn_resnet34_vd   | IC03,13,15,IIIT,etc | 64 | 8 | 84.45 | 76.48 | 6694.84 | O3 |  [mindocr_crnn](https://github.com/mindspore-lab/mindocr/tree/main/configs/rec/crnn)   |
 | rare_resnet34_vd   | IC03,13,15,IIIT,etc | 512 | 4 | 85.19 | 449 | 4561 | O2 |  [mindocr_rare](https://github.com/mindspore-lab/mindocr/tree/main/configs/rec/rare)   |
 | visionlan_resnet45| IC03,13,15,IIIT,etc | 192| 4 | 90.61 | 417 | 1840 | O2 | [mindocr_visionlan](https://github.com/mindspore-lab/mindocr/blob/main/configs/rec/visionlan) |
-| master_resnet31   | IC03,13,15,IIIT,etc | 512 | 4 | 90.37 | 747 | 2741 | O2 |  [mindocr_rare](https://github.com/mindspore-lab/mindocr/tree/main/configs/rec/master)   |
+| master_resnet31   | IC03,13,15,IIIT,etc | 512 | 4 | 90.37 | 747 | 2741 | O2 |  [mindocr_master](https://github.com/mindspore-lab/mindocr/tree/main/configs/rec/master)   |
 | robustscanner_resnet31 | IC13,15,IIIT,SVT,etc | 256 | 4 | 87.86 |   825   |   310   | O0  |           [mindocr_robustscanner](https://github.com/mindspore-lab/mindocr/blob/main/configs/rec/robustscanner)            |
 
 ### Text Direction Classification

--- a/mindocr/models/heads/rec_master_decoder.py
+++ b/mindocr/models/heads/rec_master_decoder.py
@@ -66,7 +66,10 @@ class MasterDecoder(nn.Cell):
         )
         self.position = PositionalEncoding(in_channels, dropout)
         self.stacks = stacks
-        self.dropout = nn.Dropout(keep_prob=1 - dropout)
+        if is_ms_version_2():
+            self.dropout = nn.Dropout(p=dropout)
+        else:
+            self.dropout = nn.Dropout(keep_prob=1 - dropout)
         self.layer_norm = nn.LayerNorm([in_channels], epsilon=1e-6)
         self.embedding = nn.Embedding(out_channels, in_channels)
         self.sqrt_model_size = np.sqrt(in_channels)
@@ -133,7 +136,7 @@ class MasterDecoder(nn.Cell):
         num_steps = self.batch_max_length + 1  # for <STOP> symbol
 
         if targets is not None:
-            # training
+            # training branch
             targets = targets[0]
             targets = targets[:, :-1]
             target_mask = self._generate_target_mask(targets)

--- a/mindocr/models/necks/master_encoder.py
+++ b/mindocr/models/necks/master_encoder.py
@@ -4,6 +4,7 @@ import mindspore.nn as nn
 import mindspore.ops as ops
 from mindspore import Tensor
 
+from ...utils.misc import is_ms_version_2
 from ..utils import MultiHeadAttention, PositionalEncoding, PositionwiseFeedForward
 
 
@@ -51,7 +52,10 @@ class MasterEncoder(nn.Cell):
         self.position = PositionalEncoding(in_channels, dropout)
         self.layer_norm = nn.LayerNorm([in_channels], epsilon=1e-6)
         self.stacks = stacks
-        self.dropout = nn.Dropout(keep_prob=1 - dropout)
+        if is_ms_version_2():
+            self.dropout = nn.Dropout(p=dropout)
+        else:
+            self.dropout = nn.Dropout(keep_prob=1 - dropout)
         self.with_encoder = with_encoder
 
     def construct(self, features: List[Tensor]) -> Tensor:

--- a/mindocr/models/rec_master.py
+++ b/mindocr/models/rec_master.py
@@ -11,7 +11,7 @@ def _cfg(url="", input_size=(3, 32, 100), **kwargs):
 
 default_cfgs = {
     "master_resnet31": _cfg(
-        url="https://download.mindspore.cn/toolkits/mindocr/master/master_resnet31-7565c75f.ckpt",
+        url="https://download.mindspore.cn/toolkits/mindocr/master/master_resnet31-e7bfbc97.ckpt",
         input_size=(3, 48, 160),
     ),
 }


### PR DESCRIPTION
- Fixed the scaling value bug in attention cell, and also make the network runnable in pynative mode. Refer to the issue https://gitee.com/mindspore/mindspore/issues/I7M0XX#note_19754663. This modification make the network slightly more accurate.
- Use `inf` value to replace the large value in attention's mask, thus we can remove the type casting of fp32 during the attention calculation safely, it brings us a roughly 5% speed improvement.
- Clean all warning of the dropout in Master model in MindSpore 2.0

Thank you for your contribution to the MindOCR repo.
Before submitting this PR, please make sure:

- [x] You have read the [Contributing Guidelines on pull requests](https://github.com/mindspore-lab/mindcv/blob/main/CONTRIBUTING.md)
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved terminology
- [x] You have added unit tests

## Motivation

(Write your motivation for proposed changes here.)

## Test Plan

(How should this PR be tested? Do you require special setup to run the test or repro the fixed bug?)

## Related Issues and PRs

(Is this PR part of a group of changes? Link the other relevant PRs and Issues here. Use https://help.github.com/en/articles/closing-issues-using-keywords for help on GitHub syntax)
