### PR TITLE
load_checkpoint does not allow empty ckpt file

### DIFF
--- a/mindocr/models/backbones/mindcv_models/utils.py
+++ b/mindocr/models/backbones/mindcv_models/utils.py
@@ -72,13 +72,12 @@ def load_pretrained(model, default_cfg, num_classes=1000, in_channels=3, filter_
 
     try:
         param_dict = load_checkpoint(file_path)
-    except Exception:
-        _logger.error(
+    except Exception as e:
+        raise ValueError(
             f"Fails to load the checkpoint. Please check whether the checkpoint is downloaded successfully"
             f"as `{file_path}` and is not zero-byte. You may try to manually download the checkpoint "
             f"from {default_cfg['url']}"
-        )
-        param_dict = dict()
+        ) from e
 
     if auto_mapping:
         param_dict = auto_map(model, param_dict)

--- a/tests/ut/test_mindir_export.py
+++ b/tests/ut/test_mindir_export.py
@@ -10,7 +10,7 @@ from mindocr import build_model, list_models
 from tools.export import export
 
 
-@pytest.mark.parametrize("model_name", ["dbnet_resnet50", "crnn_resnet34", "rare_resnet34"])
+@pytest.mark.parametrize("model_name", ["dbnet_resnet50", "crnn_resnet34", "rare_resnet34", "visionlan_resnet45"])
 def test_mindir_infer(model_name):
     ms.set_context(mode=ms.GRAPH_MODE)
 
@@ -20,6 +20,8 @@ def test_mindir_infer(model_name):
 
     if task == "rec":
         c, h, w = 3, 32, 100
+        if "visionlan" in model_name:
+            c, h, w = 3, 64, 256
     else:
         c, h, w = 3, 736, 1280
 


### PR DESCRIPTION
When loading a pretrained model using `build_model(model_name, pretrained=True)`, sometimes due to internet connection error, the downloaded ckpt file was empty.  If using the old `load_checkpoint`, it will only give warnings that can be easily ignored among lots of other warnings.  

I think  `load_checkpoint` should not allow loading empty ckpt files. When the loading failed, the program should be stopped.

In addition, `visionlan_resnet45` is added to `test_mindir_export.py` and has passed the test.
