### PR TITLE
visionlan augmentation revision: remove CVRescale

### DIFF
--- a/configs/rec/visionlan/visionlan_resnet45_LA.yaml
+++ b/configs/rec/visionlan/visionlan_resnet45_LA.yaml
@@ -109,6 +109,7 @@ train:
           lower: *lower
       - SVTRRecAug:
           aug_type: 0
+          deterioration_factor: null
       - SVTRRecResizeImg:
           image_shape: [64, 256] # H, W
           padding: False

--- a/configs/rec/visionlan/visionlan_resnet45_LF_1.yaml
+++ b/configs/rec/visionlan/visionlan_resnet45_LF_1.yaml
@@ -108,6 +108,7 @@ train:
           lower: *lower
       - SVTRRecAug:
           aug_type: 0
+          deterioration_factor: null
       - SVTRRecResizeImg:
           image_shape: [64, 256] # H, W
           padding: False

--- a/configs/rec/visionlan/visionlan_resnet45_LF_2.yaml
+++ b/configs/rec/visionlan/visionlan_resnet45_LF_2.yaml
@@ -108,6 +108,7 @@ train:
           lower: *lower
       - SVTRRecAug:
           aug_type: 0
+          deterioration_factor: null
       - SVTRRecResizeImg:
           image_shape: [64, 256] # H, W
           padding: False

--- a/mindocr/data/transforms/svtr_transform.py
+++ b/mindocr/data/transforms/svtr_transform.py
@@ -369,7 +369,9 @@ class SVTRGeometry(object):
 
 
 class SVTRRecAug(object):
-    def __init__(self, aug_type=0, geometry_p=0.5, deterioration_p=0.25, colorjitter_p=0.25, **kwargs):
+    def __init__(
+        self, aug_type=0, geometry_p=0.5, deterioration_p=0.25, deterioration_factor=4, colorjitter_p=0.25, **kwargs
+    ):
         self.transforms = Compose(
             [
                 SVTRGeometry(
@@ -381,7 +383,7 @@ class SVTRRecAug(object):
                     distortion=0.5,
                     p=geometry_p,
                 ),
-                SVTRDeterioration(variance=20, degrees=6, factor=4, p=deterioration_p),
+                SVTRDeterioration(variance=20, degrees=6, factor=deterioration_factor, p=deterioration_p),
                 CVColorJitter(
                     brightness=0.5,
                     contrast=0.5,


### PR DESCRIPTION
After `data/transforms/svtr_transform.py` has been revised to ensure randomness during training, visionlan training gets difficulty in loss convergence. I checked and found that `CVRescale` is the reason. 

After removing `CVRescale` from `SVTRRecAug` by setting `deterioration_factor` to `None`, the visionlan training gets fast convergence. This revision leads to a model with `90.86%` (previously it was `90.60%`) on ten benchmarks. I'm not ready to update the checkpoint files until I have tested the new data pipeline with the augmentation revision.