### PR TITLE
visionlan aug edits: remove CVRescale

### DIFF
--- a/configs/rec/visionlan/visionlan_resnet45_LA.yaml
+++ b/configs/rec/visionlan/visionlan_resnet45_LA.yaml
@@ -113,7 +113,7 @@ train:
       - SVTRDeterioration:
           variance: 20
           degrees: 6
-          factor: 4
+          factor: null
           p: 0.25
       - CVColorJitter:
           p: 0.25

--- a/configs/rec/visionlan/visionlan_resnet45_LF_1.yaml
+++ b/configs/rec/visionlan/visionlan_resnet45_LF_1.yaml
@@ -112,7 +112,7 @@ train:
       - SVTRDeterioration:
           variance: 20
           degrees: 6
-          factor: 4
+          factor: null
           p: 0.25
       - CVColorJitter:
           p: 0.25

--- a/configs/rec/visionlan/visionlan_resnet45_LF_2.yaml
+++ b/configs/rec/visionlan/visionlan_resnet45_LF_2.yaml
@@ -112,7 +112,7 @@ train:
       - SVTRDeterioration:
           variance: 20
           degrees: 6
-          factor: 4
+          factor: null
           p: 0.25
       - CVColorJitter:
           p: 0.25


### PR DESCRIPTION

Remove `CVRescale` from the augmentation list by setting `SVTRDeterioration.factor` to `None`. This augmentation is now aligned with the augmentation in the current main branch.