### PR TITLE
DBLoss bug fix

### DIFF
--- a/mindocr/losses/det_loss.py
+++ b/mindocr/losses/det_loss.py
@@ -155,7 +155,9 @@ class BalancedBCELoss(nn.LossBase):
         pos_count = positive.sum(axis=(1, 2), keepdims=True).astype(ms.int32)
         neg_count = negative.sum(axis=(1, 2), keepdims=True).astype(ms.int32)
         neg_count = ops.minimum(neg_count, pos_count * self._negative_ratio).squeeze(axis=(1, 2))
-        neg_count = ops.maximum(neg_count, 10)  # in case when an image has no text instances
+        # in case when an image has no text instances (`pos_count` == 0), set `neg_count` to a small value
+        # to avoid a RuntimeError during `min_neg_score` calculation
+        neg_count = ops.maximum(neg_count, 10)
 
         loss = self._bce_loss(pred, gt, None)
 

--- a/mindocr/losses/det_loss.py
+++ b/mindocr/losses/det_loss.py
@@ -155,6 +155,7 @@ class BalancedBCELoss(nn.LossBase):
         pos_count = positive.sum(axis=(1, 2), keepdims=True).astype(ms.int32)
         neg_count = negative.sum(axis=(1, 2), keepdims=True).astype(ms.int32)
         neg_count = ops.minimum(neg_count, pos_count * self._negative_ratio).squeeze(axis=(1, 2))
+        neg_count = ops.maximum(neg_count, 10)  # in case when an image has no text instances
 
         loss = self._bce_loss(pred, gt, None)
 


### PR DESCRIPTION
Thank you for your contribution to the MindOCR repo.
Before submitting this PR, please make sure:

- [x] You have read the [Contributing Guidelines on pull requests](https://github.com/mindspore-lab/mindcv/blob/main/CONTRIBUTING.md)
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved terminology
- [ ] You have added unit tests

## Motivation

This PR fixes a bug in DBLoss that caused execution to crash on GPU and CPU when calculating loss on images with no text instances in them.

## Related Issues and PRs

Fix for Issue #536.