### PR TITLE
add new bordermap

### DIFF
--- a/mindocr/data/transforms/det_transforms.py
+++ b/mindocr/data/transforms/det_transforms.py
@@ -233,12 +233,16 @@ class BorderMap:
         shrink_ratio: polygon shrink ratio (same as in ShrinkBinaryMap) which is used to calculate width of the border.
         thresh_min: minimum value for the border map (normalized map).
         thresh_max: maximum value for the border map (normalized map).
+        (experimental) fast: boolean to use new border map implementation
     """
 
-    def __init__(self, shrink_ratio: float = 0.4, thresh_min: float = 0.3, thresh_max: float = 0.7, **kwargs):
+    def __init__(
+        self, shrink_ratio: float = 0.4, thresh_min: float = 0.3, thresh_max: float = 0.7, fast: bool = False, **kwargs
+    ):
         self._thresh_min = thresh_min
         self._thresh_max = thresh_max
         self._dist_coef = 1 - shrink_ratio**2
+        self.fast = fast
 
     def __call__(self, data: dict) -> dict:
         border = np.zeros(data["image"].shape[:2], dtype=np.float32)
@@ -246,7 +250,10 @@ class BorderMap:
 
         for i in range(len(data["polys"])):
             if not data["ignore_tags"][i]:
-                self._draw_border(data["polys"][i], border, mask=mask)
+                if self.fast:
+                    self._draw_border_fast(data["polys"][i], border, mask=mask)
+                else:
+                    self._draw_border(data["polys"][i], border, mask=mask)
         border = border * (self._thresh_max - self._thresh_min) + self._thresh_min
 
         data["thresh_map"] = border
@@ -282,6 +289,49 @@ class BorderMap:
             ],
             border[min_valid[1] : max_valid[1] + 1, min_valid[0] : max_valid[0] + 1],
         )
+
+    def _draw_border_fast(self, np_poly: np.ndarray, border: np.ndarray, mask: np.ndarray):
+        # draw mask
+        poly = Polygon(np_poly)
+        distance = self._dist_coef * poly.area / poly.length
+        padded_polygon = np.array(expand_poly(np_poly, distance)[0], dtype=np.int32)
+        cv2.fillPoly(mask, [padded_polygon], 1.0)
+
+        # draw border
+        poly_border = np.zeros(border.shape[:2], dtype=np.float32)  # empty image to draw border on
+
+        pad_width = round(distance)
+        poly_border = np.pad(
+            poly_border, pad_width, mode="constant"
+        )  # pad image to account for polygons at the edges of image
+
+        thickness = round(distance * 2) - 1
+        cv2.polylines(
+            poly_border, [np.array(np_poly, dtype=np.int32) + pad_width], True, 1.0, thickness
+        )  # draw white polygon on black image
+
+        distance_map = np.clip(
+            cv2.distanceTransform((poly_border * 255).astype(np.uint8), cv2.DIST_C, cv2.DIST_MASK_3) / (thickness // 2),
+            0,
+            1,
+        )  # calculate distance from foreground to closest background
+
+        distance_map = distance_map[
+            pad_width : poly_border.shape[0] - pad_width, pad_width : poly_border.shape[1] - pad_width
+        ]  # un-pad the image
+
+        min_vals, max_vals = np.min(padded_polygon, axis=0) - thickness, np.max(padded_polygon, axis=0) + thickness
+
+        min_valid = np.clip(min_vals, 0, np.array(border.shape[::-1]) - 1)  # shape reverse order: w, h
+        max_valid = np.clip(max_vals, 0, np.array(border.shape[::-1]) - 1)
+
+        border[min_valid[1] : max_valid[1] + 1, min_valid[0] : max_valid[0] + 1] = np.fmax(
+            distance_map[
+                min_valid[1] : max_valid[1] + 1,
+                min_valid[0] : max_valid[0] + 1,
+            ],
+            border[min_valid[1] : max_valid[1] + 1, min_valid[0] : max_valid[0] + 1],
+        )  # draw the distance map on the combined border map
 
     @staticmethod
     def _distance(xs: np.ndarray, ys: np.ndarray, point_1: np.ndarray, point_2: np.ndarray) -> np.ndarray:


### PR DESCRIPTION
Thank you for your contribution to the MindOCR repo.
Before submitting this PR, please make sure:

- [x] You have read the [Contributing Guidelines on pull requests](https://github.com/mindspore-lab/mindcv/blob/main/CONTRIBUTING.md)
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved terminology
- [ ] You have added unit tests

This experimental pull request introduces a new implementation of the `_draw_border()` method of the `BorderMap` transform in the training pipeline. 

The DBNet model uses threshold maps (aka border maps) in the training process to predict text instances borders. The `_draw_border()` method of `BorderMap` generates these borders for each text polygon in the image by computing the distance from each polygon edge to each pixel in the image.

Therefore, the original implementation of the `_draw_border()` method is particularly slow when a dataset contains large number of edges in the ground truth polygons. The new implementation in this PR utilizes OpenCV's `distanceTransform()` function to compute the distance map, resulting in faster processing of datasets with a large number of edges in the ground truth polygons, e.g. **Reading the Seal Title (ReST)** dataset, which contains polygons with 100+ vertices.

> Note: The motivation behind this experiment was the extremely slow training on the ReST dataset due to the very slow original implementation of the BorderMap transform. Therefore, this implementation of the BorderMap may, for now, be primarily used for the ReST dataset. 

The pros and cons of the new implementation are highlighted as follows:

**Pros:**
- The processing speed difference between the new implementation and the old implementation is huge for datasets with a large number of edges e.g. ReST dataset. Some results along with speed metrics from the ReST dataset are displayed below, which show the vast increase in speed using the new implementation.
- Visually, the maps are very similar (as seen below).
- The new implementation also gives identical training metrics as the original implementation, as tested on the ICDAR2015 dataset; therefore, there is no effect of the new threshold map method on the training process.

| Metric |New Implementation             |  Original Implementation
|:---:|:-------------------------:|:-------------------------:
| 1.  |<img alt="" src="https://github.com/mindspore-lab/mindocr/assets/44549936/d3c99782-08da-4253-bf7c-5fd3322a9fef" width="200"/>  |  <img alt="" src="https://github.com/mindspore-lab/mindocr/assets/44549936/e4088d8a-0372-4f13-80ea-7d51764e4d1c" width="200"/>
| Vertices | 391 | 391
| Time Taken | 0.0182 seconds | 18.7 seconds
| 2.  |<img alt="" src="https://github.com/mindspore-lab/mindocr/assets/44549936/a5d2f907-a97c-4cc6-9338-185f99a7cbc2" width="200"/>  |  <img alt="" src="https://github.com/mindspore-lab/mindocr/assets/44549936/0bc22abc-63b0-40cd-9e84-a2e61bff112f" width="200"/> 
| Vertices | 933 | 933
| Time Taken | 0.0196 seconds | 28.8 seconds


**Cons:**
- In sections of polygons where the polygons are extremely thin, the new implementation paints the inside of the polygon as well, unlike the original implementation (**example shown below from ICDAR2015**). This may affect accuracy in training, but no discrepancy in training metrics has been observed so far (identical results in ICDAR2015).

|New Implementation             |  Original Implementation
|:-------------------------:|:-------------------------:
|<img alt="" src="https://github.com/mindspore-lab/mindocr/assets/44549936/5139dfe3-a8dc-43ba-95eb-2be528292590" width="300"/> |  <img alt="" src="https://github.com/mindspore-lab/mindocr/assets/44549936/0cca104d-b71b-4c37-a864-e902b62f72c7" width="300"/>
| Inside of very thin polygons is painted | Inside of polygons is not painted


- For datasets with a low number of edges (mostly the ones with quadrilateral ground truths), the new map operates at comparable speeds with the original map; thus, the old map may still be used for those datasets (for the sake of consistency with the original approach). 

The performance of the two border maps on 50 images for each vertex count with 1 randomly generated polygon is shown below (*Note: this performance benchmarking was ran independently (not through the pipeline)*):

<img alt="" src="https://github.com/mindspore-lab/mindocr/assets/44549936/19c1d979-e537-45cc-b69e-862eb8862bcb" width="400"/> 