### PR TITLE
fix the bug that the zero-text instance still in training when using custom dictionary

### DIFF
--- a/mindocr/data/rec_lmdb_dataset.py
+++ b/mindocr/data/rec_lmdb_dataset.py
@@ -168,7 +168,9 @@ class LMDBDataset(BaseDataset):
     ) -> np.ndarray:
         _logger.info("Start filtering the idx list which has zero text...")
         if character_dict_path is None:
-            char_list = [c for c in "0123456789abcdefghijklmnopqrstuvwxyz"]
+            char_list = list("0123456789abcdefghijklmnopqrstuvwxyz")
+            # in case when lower=True, we don't want to filter out the original upper case characters
+            char_list = list(char_list) + [x.upper() for x in char_list]
         else:
             char_list = []
             with open(character_dict_path, "r") as f:
@@ -176,7 +178,6 @@ class LMDBDataset(BaseDataset):
                     c = line.rstrip("\n\r")
                     char_list.append(c)
 
-        char_list = [x.lower() for x in char_list] + [x.upper() for x in char_list]
         char_list = set(char_list)
 
         new_idx_list = list()


### PR DESCRIPTION
…zed dictionary

Thank you for your contribution to the MindOCR repo.
Before submitting this PR, please make sure:

- [ ] You have read the [Contributing Guidelines on pull requests](https://github.com/mindspore-lab/mindcv/blob/main/CONTRIBUTING.md)
- [ ] Your code builds clean without any errors or warnings
- [ ] You are using approved terminology
- [ ] You have added unit tests

## Motivation

(Write your motivation for proposed changes here.)

## Test Plan

(How should this PR be tested? Do you require special setup to run the test or repro the fixed bug?)

## Related Issues and PRs

(Is this PR part of a group of changes? Link the other relevant PRs and Issues here. Use https://help.github.com/en/articles/closing-issues-using-keywords for help on GitHub syntax)
