### PR TITLE
remove Decode to read images in correct orientation

### DIFF
--- a/configs/det/dbnet/db++_r50_icdar15.yaml
+++ b/configs/det/dbnet/db++_r50_icdar15.yaml
@@ -77,7 +77,6 @@ train:
     label_file: ic15/det/train/det_gt.txt
     sample_ratio: 1.0
     transform_pipeline:
-      - Decode:
       - DetLabelEncode:
       - RandomHorizontalFlip:
           p: 0.5
@@ -129,7 +128,6 @@ eval:
     label_file: ic15/det/test/det_gt.txt
     sample_ratio: 1.0
     transform_pipeline:
-      - Decode:
       - DetLabelEncode:
       - DetResize:
           target_size: [ 1152, 2048 ]

--- a/configs/det/dbnet/db_mobilenetv3_icdar15.yaml
+++ b/configs/det/dbnet/db_mobilenetv3_icdar15.yaml
@@ -79,7 +79,6 @@ train:
     label_file: ic15/det/train/det_gt.txt
     sample_ratio: 1.0
     transform_pipeline:
-      - Decode:
       - DetLabelEncode:
       - RandomHorizontalFlip:
           p: 0.5
@@ -131,7 +130,6 @@ eval:
     label_file: ic15/det/test/det_gt.txt
     sample_ratio: 1.0
     transform_pipeline:
-      - Decode:
       - DetLabelEncode:
       - DetResize:  # GridResize 32
           target_size: [ 736, 1280 ]

--- a/configs/det/dbnet/db_r18_ctw1500.yaml
+++ b/configs/det/dbnet/db_r18_ctw1500.yaml
@@ -73,7 +73,6 @@ train:
     label_file: ctw1500/train_det_gt.txt
     sample_ratio: 1.0
     transform_pipeline:
-      - Decode:
       - DetLabelEncode:
       - RandomHorizontalFlip:
           p: 0.5
@@ -121,7 +120,6 @@ eval:
     label_file: ctw1500/test_det_gt.txt
     sample_ratio: 1.0
     transform_pipeline:
-      - Decode:
       - DetLabelEncode:
       - DetResize:
           target_size: [ 1024, 1024 ]

--- a/configs/det/dbnet/db_r18_icdar15.yaml
+++ b/configs/det/dbnet/db_r18_icdar15.yaml
@@ -68,13 +68,12 @@ train:
   dataset_sink_mode: True
   dataset:
     type: DetDataset
-    mindrecord: True
+    mindrecord: False
     dataset_root: /data/ocr_datasets
     data_dir: ic15/det/MR/train
     label_file: ''
     sample_ratio: 1.0
     transform_pipeline:
-      - Decode:
       - DetLabelEncode:
       - RandomHorizontalFlip:
           p: 0.5
@@ -121,13 +120,12 @@ eval:
   dataset_sink_mode: False
   dataset:
     type: DetDataset
-    mindrecord: True
+    mindrecord: False
     dataset_root: /data/ocr_datasets
     data_dir: ic15/det/MR/test
     label_file: ''
     sample_ratio: 1.0
     transform_pipeline:
-      - Decode:
       - DetLabelEncode:
       - DetResize:  # GridResize 32
           target_size: [ 736, 1280 ]

--- a/configs/det/dbnet/db_r18_mlt2017.yaml
+++ b/configs/det/dbnet/db_r18_mlt2017.yaml
@@ -73,7 +73,6 @@ train:
     label_file: MLT_2017/train_det_gt.txt
     sample_ratio: 1.0
     transform_pipeline:
-      - Decode:
       - DetLabelEncode:
       - RandomHorizontalFlip:
           p: 0.5
@@ -127,7 +126,6 @@ eval:
     label_file: MLT_2017/validation_det_gt.txt
     sample_ratio: 1.0
     transform_pipeline:
-      - Decode:
       - DetLabelEncode:
       - DetResize:
           target_size: [ 1152, 2048 ] # h, w

--- a/configs/det/dbnet/db_r18_synthtext.yaml
+++ b/configs/det/dbnet/db_r18_synthtext.yaml
@@ -60,7 +60,6 @@ train:
     label_file: SynthText/gt_processed.mat
     sample_ratio: 1.0
     transform_pipeline:
-      - Decode:
       - RandomHorizontalFlip:
           p: 0.5
       - RandomRotate:

--- a/configs/det/dbnet/db_r18_td500.yaml
+++ b/configs/det/dbnet/db_r18_td500.yaml
@@ -74,7 +74,6 @@ train:
     label_file: TD500_TR400/train_gt_labels.txt
     sample_ratio: 1.0
     transform_pipeline:
-      - Decode:
       - DetLabelEncode:
       - RandomHorizontalFlip:
           p: 0.5
@@ -126,7 +125,6 @@ eval:
     label_file: MSRA-TD500/test_det_gt.txt
     sample_ratio: 1.0
     transform_pipeline:
-      - Decode:
       - DetLabelEncode:
       - DetResize:  #ScalePadImage
           target_size: [ 800, 800 ] # h, w

--- a/configs/det/dbnet/db_r18_totaltext.yaml
+++ b/configs/det/dbnet/db_r18_totaltext.yaml
@@ -74,7 +74,6 @@ train:
     label_file: totaltext/train_det_gt.txt
     sample_ratio: 1.0
     transform_pipeline:
-      - Decode:
       - DetLabelEncode:
       - RandomHorizontalFlip:
           p: 0.5
@@ -126,7 +125,6 @@ eval:
     label_file: totaltext/test_det_gt.txt
     sample_ratio: 1.0
     transform_pipeline:
-      - Decode:
       - DetLabelEncode:
       - DetResize:
           target_size: [ 1152, 2048 ] # h, w

--- a/configs/det/dbnet/db_r50_ctw1500.yaml
+++ b/configs/det/dbnet/db_r50_ctw1500.yaml
@@ -73,7 +73,6 @@ train:
     label_file: ctw1500/train_det_gt.txt
     sample_ratio: 1.0
     transform_pipeline:
-      - Decode:
       - DetLabelEncode:
       - RandomHorizontalFlip:
           p: 0.5
@@ -121,7 +120,6 @@ eval:
     label_file: ctw1500/test_det_gt.txt
     sample_ratio: 1.0
     transform_pipeline:
-      - Decode:
       - DetLabelEncode:
       - DetResize:
           target_size: [ 1024, 1024 ] # h, w

--- a/configs/det/dbnet/db_r50_icdar15.yaml
+++ b/configs/det/dbnet/db_r50_icdar15.yaml
@@ -67,13 +67,12 @@ train:
   dataset_sink_mode: True
   dataset:
     type: DetDataset
-    mindrecord: True
+    mindrecord: False
     dataset_root: /data/ocr_datasets
     data_dir: ic15/det/MR/train
     label_file: ''
     sample_ratio: 1.0
     transform_pipeline:
-      - Decode:
       - DetLabelEncode:
       - RandomHorizontalFlip:
           p: 0.5
@@ -120,13 +119,12 @@ eval:
   dataset_sink_mode: False
   dataset:
     type: DetDataset
-    mindrecord: True
+    mindrecord: False
     dataset_root: /data/ocr_datasets
     data_dir: ic15/det/MR/test
     label_file: ''
     sample_ratio: 1.0
     transform_pipeline:
-      - Decode:
       - DetLabelEncode:
       - DetResize:  # GridResize 32
           target_size: [ 736, 1280 ]

--- a/configs/det/dbnet/db_r50_mlt2017.yaml
+++ b/configs/det/dbnet/db_r50_mlt2017.yaml
@@ -73,7 +73,6 @@ train:
     label_file: MLT_2017/train_det_gt.txt
     sample_ratio: 1.0
     transform_pipeline:
-      - Decode:
       - DetLabelEncode:
       - RandomHorizontalFlip:
           p: 0.5
@@ -127,7 +126,6 @@ eval:
     label_file: MLT_2017/validation_det_gt.txt
     sample_ratio: 1.0
     transform_pipeline:
-      - Decode:
       - DetLabelEncode:
       - DetResize:
           target_size: [ 1152, 2048 ] # h, w

--- a/configs/det/dbnet/db_r50_synthtext.yaml
+++ b/configs/det/dbnet/db_r50_synthtext.yaml
@@ -60,7 +60,6 @@ train:
     label_file: SynthText/gt_processed.mat
     sample_ratio: 1.0
     transform_pipeline:
-      - Decode:
       - RandomHorizontalFlip:
           p: 0.5
       - RandomRotate:

--- a/configs/det/dbnet/db_r50_td500.yaml
+++ b/configs/det/dbnet/db_r50_td500.yaml
@@ -74,7 +74,6 @@ train:
     label_file: TD500_TR400/train_gt_labels.txt
     sample_ratio: 1.0
     transform_pipeline:
-      - Decode:
       - DetLabelEncode:
       - RandomHorizontalFlip:
           p: 0.5
@@ -126,7 +125,6 @@ eval:
     label_file: MSRA-TD500/test_det_gt.txt
     sample_ratio: 1.0
     transform_pipeline:
-      - Decode:
       - DetLabelEncode:
       - DetResize:  # ScalePadImage
           target_size: [ 800, 800] # h, w

--- a/configs/det/dbnet/db_r50_totaltext.yaml
+++ b/configs/det/dbnet/db_r50_totaltext.yaml
@@ -74,7 +74,6 @@ train:
     label_file: totaltext/train_det_gt.txt
     sample_ratio: 1.0
     transform_pipeline:
-      - Decode:
       - DetLabelEncode:
       - RandomHorizontalFlip:
           p: 0.5
@@ -126,7 +125,6 @@ eval:
     label_file: totaltext/test_det_gt.txt
     sample_ratio: 1.0
     transform_pipeline:
-      - Decode:
       - DetLabelEncode:
       - DetResize:
           target_size: [ 1152, 2048 ] # h, w

--- a/configs/det/east/east_mobilenetv3_icdar15.yaml
+++ b/configs/det/east/east_mobilenetv3_icdar15.yaml
@@ -72,7 +72,6 @@ train:
     label_file: ic15/det/train/det_gt.txt
     sample_ratio: 1.0
     transform_pipeline:
-      - Decode:
       - DetLabelEncode:
       - EASTProcessTrain:
           scale: 0.25
@@ -108,7 +107,6 @@ eval:
     label_file: ic15/det/test/det_gt.txt
     sample_ratio: 1.0
     transform_pipeline:
-      - Decode:
       - DetLabelEncode:
       - DetResize:
           target_size: [720, 1280]

--- a/configs/det/east/east_r50_icdar15.yaml
+++ b/configs/det/east/east_r50_icdar15.yaml
@@ -66,7 +66,6 @@ train:
     label_file: ic15/det/train/det_gt.txt
     sample_ratio: 1.0
     transform_pipeline:
-      - Decode:
       - DetLabelEncode:
       - EASTProcessTrain:
           scale: 0.25
@@ -102,7 +101,6 @@ eval:
     label_file: ic15/det/test/det_gt.txt
     sample_ratio: 1.0
     transform_pipeline:
-      - Decode:
       - DetLabelEncode:
       - DetResize:
           target_size: [720, 1280]

--- a/configs/det/fcenet/fce_icdar15.yaml
+++ b/configs/det/fcenet/fce_icdar15.yaml
@@ -61,7 +61,6 @@ train:
     label_file: icdar/train_det_gt.txt
     sample_ratio: 1.0
     transform_pipeline:
-      - Decode:
       - DetLabelEncode:
       - DetResize:
           target_size: [ 800, 800 ]
@@ -114,7 +113,6 @@ eval:
     sample_ratio: 1.0
     shuffle: False
     transform_pipeline:
-      - Decode:
       - DetLabelEncode:
       - DetResize:
           target_size: [ 800, 800 ]

--- a/configs/det/psenet/pse_mv3_icdar15.yaml
+++ b/configs/det/psenet/pse_mv3_icdar15.yaml
@@ -70,7 +70,6 @@ train: #  ema: True
     label_file: ic15/train_det_gt.txt
     sample_ratio: 1.0
     transform_pipeline:
-      - Decode:
       - DetLabelEncode:
       - RandomHorizontalFlip:
           p: 0.5
@@ -116,7 +115,6 @@ eval:
     label_file: ic15/test_det_gt.txt
     sample_ratio: 1.0
     transform_pipeline:
-      - Decode:
       - DetLabelEncode:
       - DetResize:
           limit_side_len: 736 # 736

--- a/configs/det/psenet/pse_r152_ctw1500.yaml
+++ b/configs/det/psenet/pse_r152_ctw1500.yaml
@@ -65,7 +65,6 @@ train:
     label_file: ctw1500/train_det_gt.txt
     sample_ratio: 1.0
     transform_pipeline:
-      - Decode:
       - DetLabelEncode:
       - RandomHorizontalFlip:
           p: 0.5
@@ -108,7 +107,6 @@ eval:
     label_file: ctw1500/test_det_gt.txt
     sample_ratio: 1.0
     transform_pipeline:
-      - Decode:
       - DetLabelEncode:
       - DetResize:
           target_size: [ 1024, 1024 ] # 1280

--- a/configs/det/psenet/pse_r152_icdar15.yaml
+++ b/configs/det/psenet/pse_r152_icdar15.yaml
@@ -65,7 +65,6 @@ train:
     label_file: ic15/train_det_gt.txt
     sample_ratio: 1.0
     transform_pipeline:
-      - Decode:
       - DetLabelEncode:
       - RandomScale:
           scale_range: [ 0.5, 3.0 ]
@@ -111,7 +110,6 @@ eval:
     label_file: ic15/det/test/det_gt.txt
     sample_ratio: 1.0
     transform_pipeline:
-      - Decode:
       - DetLabelEncode:
       - DetResize:
           limit_side_len: 736 # 736 1472

--- a/configs/det/psenet/pse_r50_icdar15.yaml
+++ b/configs/det/psenet/pse_r50_icdar15.yaml
@@ -66,7 +66,6 @@ train: #  ema: True
     label_file: ic15/train_det_gt.txt
     sample_ratio: 1.0
     transform_pipeline:
-      - Decode:
       - DetLabelEncode:
       - RandomScale:
           scale_range: [ 0.1, 2.0 ] # [0.2, 3.0]
@@ -110,7 +109,6 @@ eval:
     label_file: ic15/test_det_gt.txt
     sample_ratio: 1.0
     transform_pipeline:
-      - Decode:
       - DetLabelEncode:
       - DetResize:
           limit_side_len: 736 # 736

--- a/mindocr/data/det_dataset.py
+++ b/mindocr/data/det_dataset.py
@@ -3,6 +3,7 @@ import os
 import random
 from typing import List, Union
 
+import cv2
 import numpy as np
 from scipy.io import loadmat
 
@@ -68,7 +69,7 @@ class DetDataset(BaseDataset):
         self.output_columns = ["image", "label"]
 
     def __getitem__(self, index):
-        image = np.fromfile(self.data_list[index]["img_path"], np.uint8)
+        image = cv2.cvtColor(cv2.imread(self.data_list[index]["img_path"]), cv2.COLOR_BGR2RGB)
         return image, self.data_list[index]["label"]
 
     def load_data_list(


### PR DESCRIPTION
Thank you for your contribution to the MindOCR repo.
Before submitting this PR, please make sure:

- [x] You have read the [Contributing Guidelines on pull requests](https://github.com/mindspore-lab/mindcv/blob/main/CONTRIBUTING.md)
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved terminology
- [ ] You have added unit tests

## Motivation

MindSpore's `Decode` can't automatically rotate images based on the EXIF orientation information. Therefore, this PR replaces `Decode` with `OpenCV` for image reading in the detection task.

On the left is our original data pipeline output (uses `OpenCV`) and on the right is the new data pipeline (uses `Decode`):
![image](https://github.com/mindspore-lab/mindocr/assets/16683750/09320ddc-3c96-41a6-b791-17424271593c)
