### PR TITLE
optimize inference loading and add fcenet

### DIFF
--- a/configs/det/dbnet/README.md
+++ b/configs/det/dbnet/README.md
@@ -410,8 +410,7 @@ Please refer to [Environment Installation](../../../docs/en/inference/environmen
 - Model Conversion
 
 Please refer to [Model Conversion](../../../docs/en/inference/convert_tutorial.md#1-mindocr-models),
-and use the `converter_lite` tool for offline conversion of the MindIR file, where the `input_shape` in `configFile` needs to be filled in with the value from MindIR export,
-as mentioned above (1, 3, 736, 1280), and the format is NCHW.
+and use the `converter_lite` tool for offline conversion of the MindIR file.
 
 - Inference
 
@@ -420,11 +419,8 @@ Assuming that you obtain output.mindir after model conversion, go to the `deploy
 ```shell
 python infer.py \
     --input_images_dir=/your_path_to/test_images \
-    --device=Ascend \
-    --device_id=0 \
     --det_model_path=your_path_to/output.mindir \
     --det_model_name_or_config=../../configs/det/dbnet/db_r50_icdar15.yaml \
-    --backend=lite \
     --res_save_dir=results_dir
 ```
 

--- a/configs/det/dbnet/README_CN.md
+++ b/configs/det/dbnet/README_CN.md
@@ -386,8 +386,7 @@ python tools/export.py --model_name_or_config configs/det/dbnet/db_r50_icdar15.y
 
 - 模型转换
 
-请参考[模型转换](../../../docs/cn/inference/convert_tutorial.md#1-mindocr模型)教程，使用`converter_lite`工具对MindIR模型进行离线转换，
-其中`configFile`文件中的`input_shape`需要填写模型导出时shape，如上述的(1,3,736,1280)，格式为NCHW。
+请参考[模型转换](../../../docs/cn/inference/convert_tutorial.md#1-mindocr模型)教程，使用`converter_lite`工具对MindIR模型进行离线转换。
 
 - 执行推理
 
@@ -397,11 +396,8 @@ python tools/export.py --model_name_or_config configs/det/dbnet/db_r50_icdar15.y
 ```shell
 python infer.py \
     --input_images_dir=/your_path_to/test_images \
-    --device=Ascend \
-    --device_id=0 \
     --det_model_path=your_path_to/output.mindir \
     --det_model_name_or_config=../../configs/det/dbnet/db_r50_icdar15.yaml \
-    --backend=lite \
     --res_save_dir=results_dir
 ```
 

--- a/configs/det/east/README.md
+++ b/configs/det/east/README.md
@@ -175,8 +175,7 @@ Please refer to [Environment Installation](../../../docs/en/inference/environmen
 - Model Conversion
 
 Please refer to [Model Conversion](../../../docs/en/inference/convert_tutorial.md#1-mindocr-models),
-and use the `converter_lite` tool for offline conversion of the MindIR file, where the `input_shape` in `configFile` needs to be filled in with the value from MindIR export,
-as mentioned above (1, 3, 720, 1280), and the format is NCHW.
+and use the `converter_lite` tool for offline conversion of the MindIR file.
 
 - Inference
 
@@ -185,11 +184,8 @@ Assuming that you obtain output.mindir after model conversion, go to the `deploy
 ```shell
 python infer.py \
     --input_images_dir=/your_path_to/test_images \
-    --device=Ascend \
-    --device_id=0 \
     --det_model_path=your_path_to/output.mindir \
     --det_model_name_or_config=../../configs/det/east/east_r50_icdar15.yaml \
-    --backend=lite \
     --res_save_dir=results_dir
 ```
 

--- a/configs/det/east/README_CN.md
+++ b/configs/det/east/README_CN.md
@@ -169,8 +169,8 @@ python tools/export.py --model_name_or_config configs/det/east/east_r50_icdar15.
 
 - 模型转换
 
-请参考[模型转换](../../../docs/cn/inference/convert_tutorial.md#1-mindocr模型)教程，使用`converter_lite`工具对MindIR模型进行离线转换，
-其中`configFile`文件中的`input_shape`需要填写模型导出时shape，如上述的(1, 3, 720, 1280)，格式为NCHW。
+请参考[模型转换](../../../docs/cn/inference/convert_tutorial.md#1-mindocr模型)教程，使用`converter_lite`工具对MindIR模型进行离线转换。
+
 
 - 执行推理
 
@@ -179,11 +179,8 @@ python tools/export.py --model_name_or_config configs/det/east/east_r50_icdar15.
 ```shell
 python infer.py \
     --input_images_dir=/your_path_to/test_images \
-    --device=Ascend \
-    --device_id=0 \
     --det_model_path=your_path_to/output.mindir \
     --det_model_name_or_config=../../configs/det/east/east_r50_icdar15.yaml \
-    --backend=lite \
     --res_save_dir=results_dir
 ```
 

--- a/configs/det/fcenet/README.md
+++ b/configs/det/fcenet/README.md
@@ -195,8 +195,7 @@ Please refer to [Environment Installation](../../../docs/en/inference/environmen
 - Model Conversion
 
 Please refer to [Model Conversion](../../../docs/en/inference/convert_tutorial_en.md#1-mindocr-models),
-and use the `converter_lite` tool for offline conversion of the MindIR file, where the `input_shape` in `configFile` needs to be filled in with the value from MindIR export,
-as mentioned above (1, 3, 736, 1280), and the format is NCHW.
+and use the `converter_lite` tool for offline conversion of the MindIR file.
 
 - Inference
 
@@ -205,11 +204,8 @@ Assuming that you obtain output.mindir after model conversion, go to the `deploy
 ```shell
 python infer.py \
     --input_images_dir=/your_path_to/test_images \
-    --device=Ascend \
-    --device_id=0 \
     --det_model_path=your_path_to/output.mindir \
     --det_model_name_or_config=../../configs/det/fcenet/fce_icdar15.yaml \
-    --backend=lite \
     --res_save_dir=results_dir
 ```
 

--- a/configs/det/fcenet/README_CN.md
+++ b/configs/det/fcenet/README_CN.md
@@ -201,8 +201,7 @@ python tools/export.py --model_name_or_config configs/det/fcenet/fce_icdar15.yam
 
 - 模型转换
 
-请参考[模型转换](../../../docs/cn/inference/convert_tutorial_cn.md#1-mindocr模型)教程，使用`converter_lite`工具对MindIR模型进行离线转换，
-其中`configFile`文件中的`input_shape`需要填写模型导出时shape，如上述的(1,3,736,1280)，格式为NCHW。
+请参考[模型转换](../../../docs/cn/inference/convert_tutorial_cn.md#1-mindocr模型)教程，使用`converter_lite`工具对MindIR模型进行离线转换。
 
 - 执行推理
 
@@ -211,11 +210,8 @@ python tools/export.py --model_name_or_config configs/det/fcenet/fce_icdar15.yam
 ```shell
 python infer.py \
     --input_images_dir=/your_path_to/test_images \
-    --device=Ascend \
-    --device_id=0 \
     --det_model_path=your_path_to/output.mindir \
     --det_model_name_or_config=../../configs/det/fcenet/fce_icdar15.yaml \
-    --backend=lite \
     --res_save_dir=results_dir
 ```
 

--- a/configs/det/psenet/README.md
+++ b/configs/det/psenet/README.md
@@ -45,7 +45,7 @@ The overall architecture of PSENet is presented in Figure 1. It consists of mult
 #### Notes：
 - Context：Training context denoted as {device}x{pieces}-{MS version}{MS mode}, where mindspore mode can be G - graph mode or F - pynative mode with ms function. For example, D910x8-G is for training on 8 pieces of Ascend 910 NPU using graph mode.
 - The training time of PSENet is highly affected by data processing and varies on different machines.
-- The `input_shapes` to the exported MindIR models trained on ICDAR2015 are `(1,3,1472,2624)` for ResNet-152 backbone and `(1,3,736,1280)` for ResNet-50 backbone.
+- The `input_shapes` to the exported MindIR models trained on ICDAR2015 are `(1,3,1472,2624)` for ResNet-152 backbone and `(1,3,736,1312)` for ResNet-50 or MobileNetV3 backbone.
 - On the SCUT-CTW1500 dataset, the input_shape for exported MindIR in the link is `(1,3,1024,1024)`.
 
 ## 3. Quick Start
@@ -205,8 +205,7 @@ Please refer to [Environment Installation](../../../docs/en/inference/environmen
 - Model Conversion
 
 Please refer to [Model Conversion](../../../docs/en/inference/convert_tutorial.md#1-mindocr-models),
-and use the `converter_lite` tool for offline conversion of the MindIR file, where the `input_shape` in `configFile` needs to be filled in with the value from MindIR export,
-as mentioned above (1, 3, 1472, 2624), and the format is NCHW.
+and use the `converter_lite` tool for offline conversion of the MindIR file.
 
 - Inference
 
@@ -217,11 +216,8 @@ Assuming that you obtain output.mindir after model conversion, go to the `deploy
 ```shell
 python infer.py \
     --input_images_dir=/your_path_to/test_images \
-    --device=Ascend \
-    --device_id=0 \
     --det_model_path=your_path_to/output.mindir \
     --det_model_name_or_config=../../configs/det/psenet/pse_r152_icdar15.yaml \
-    --backend=lite \
     --res_save_dir=results_dir
 ```
 

--- a/configs/det/psenet/README_CN.md
+++ b/configs/det/psenet/README_CN.md
@@ -45,7 +45,7 @@ PSENet的整体架构图如图1所示，包含以下阶段:
 #### 注释：
 - 环境配置：训练的环境配置表示为 {处理器}x{处理器数量}-{MS模式}，其中 Mindspore 模式可以是 G-graph 模式或 F-pynative 模式。
 - PSENet的训练时长受数据处理部分超参和不同运行环境的影响非常大。
-- 在ICDAR15数据集上，以resnet152为backbone的MindIR导出时的输入Shape为`(1,3,1472,2624)` ，以resnet50为backbone的MindIR导出时的输入Shape为`(1,3,736,1280)`。
+- 在ICDAR15数据集上，以ResNet-152为backbone的MindIR导出时的输入Shape为`(1,3,1472,2624)` ，以ResNet-50或MobileNetV3为backbone的MindIR导出时的输入Shape为`(1,3,736,1312)`。
 - 在SCUT-CTW1500数据集上，MindIR导出时的输入Shape为`(1,3,1024,1024)` 。
 
 ## 3. 快速上手
@@ -204,8 +204,7 @@ python tools/export.py --model_name_or_config configs/det/psenet/pse_r152_icdar1
 
 - 模型转换
 
-请参考[模型转换](../../../docs/cn/inference/convert_tutorial.md#1-mindocr模型)教程，使用`converter_lite`工具对MindIR模型进行离线转换，
-其中`configFile`文件中的`input_shape`需要填写模型导出时shape，如上述的(1,3,1472,2624)，格式为NCHW。
+请参考[模型转换](../../../docs/cn/inference/convert_tutorial.md#1-mindocr模型)教程，使用`converter_lite`工具对MindIR模型进行离线转换。
 
 - 执行推理
 
@@ -216,11 +215,8 @@ python tools/export.py --model_name_or_config configs/det/psenet/pse_r152_icdar1
 ```shell
 python infer.py \
     --input_images_dir=/your_path_to/test_images \
-    --device=Ascend \
-    --device_id=0 \
     --det_model_path=your_path_to/output.mindir \
     --det_model_name_or_config=../../configs/det/psenet/pse_r152_icdar15.yaml \
-    --backend=lite \
     --res_save_dir=results_dir
 ```
 

--- a/configs/rec/crnn/README.md
+++ b/configs/rec/crnn/README.md
@@ -409,8 +409,7 @@ Please refer to [Environment Installation](../../../docs/en/inference/environmen
 **3. Model Conversion**
 
 Please refer to [Model Conversion](../../../docs/en/inference/convert_tutorial.md#1-mindocr-models),
-and use the `converter_lite` tool for offline conversion of the MindIR file, where the `input_shape` in `configFile` needs to be filled in with the value from MindIR export,
-as mentioned above (1, 3, 32, 100), and the format is NCHW.
+and use the `converter_lite` tool for offline conversion of the MindIR file.
 
 **4. Inference**
 
@@ -419,11 +418,8 @@ Assuming that you obtain output.mindir after model conversion, go to the `deploy
 ```shell
 python infer.py \
     --input_images_dir=/your_path_to/test_images \
-    --device=Ascend \
-    --device_id=0 \
     --rec_model_path=your_path_to/output.mindir \
     --rec_model_name_or_config=../../configs/rec/crnn/crnn_resnet34.yaml \
-    --backend=lite \
     --res_save_dir=results_dir
 ```
 

--- a/configs/rec/crnn/README_CN.md
+++ b/configs/rec/crnn/README_CN.md
@@ -409,8 +409,7 @@ python tools/export.py --model_name_or_config configs/rec/crnn/crnn_resnet34.yam
 
 **3. 模型转换**
 
-请参考[模型转换](../../../docs/cn/inference/convert_tutorial.md#1-mindocr模型)教程，使用`converter_lite`工具对MindIR模型进行离线转换，
-其中`configFile`文件中的`input_shape`需要填写模型导出时shape，如上述的(1, 3, 32, 100)，格式为NCHW。
+请参考[模型转换](../../../docs/cn/inference/convert_tutorial.md#1-mindocr模型)教程，使用`converter_lite`工具对MindIR模型进行离线转换。
 
 **4. 执行推理**
 
@@ -419,11 +418,8 @@ python tools/export.py --model_name_or_config configs/rec/crnn/crnn_resnet34.yam
 ```shell
 python infer.py \
     --input_images_dir=/your_path_to/test_images \
-    --device=Ascend \
-    --device_id=0 \
     --rec_model_path=your_path_to/output.mindir \
     --rec_model_name_or_config=../../configs/rec/crnn/crnn_resnet34.yaml \
-    --backend=lite \
     --res_save_dir=results_dir
 ```
 

--- a/configs/rec/master/README.md
+++ b/configs/rec/master/README.md
@@ -384,8 +384,7 @@ Please refer to [Environment Installation](../../../docs/en/inference/environmen
 **3. Model Conversion**
 
 Please refer to [Model Conversion](../../../docs/en/inference/convert_tutorial.md#1-mindocr-models),
-and use the `converter_lite` tool for offline conversion of the MindIR file, where the `input_shape` in `configFile` needs to be filled in with the value from MindIR export,
-as mentioned above (1, 3, 48, 160), and the format is NCHW.
+and use the `converter_lite` tool for offline conversion of the MindIR file.
 
 **4. Inference**
 
@@ -394,11 +393,8 @@ Assuming that you obtain output.mindir after model conversion, go to the `deploy
 ```shell
 python infer.py \
     --input_images_dir=/your_path_to/test_images \
-    --device=Ascend \
-    --device_id=0 \
     --rec_model_path=your_path_to/output.mindir \
     --rec_model_name_or_config=../../configs/rec/master/master_resnet31.yaml \
-    --backend=lite \
     --res_save_dir=results_dir
 ```
 

--- a/configs/rec/master/README_CN.md
+++ b/configs/rec/master/README_CN.md
@@ -382,8 +382,7 @@ python tools/export.py --model_name_or_config configs/rec/master/master_resnet31
 
 **3. 模型转换**
 
-请参考[模型转换](../../../docs/cn/inference/convert_tutorial.md#1-mindocr模型)教程，使用`converter_lite`工具对MindIR模型进行离线转换，
-其中`configFile`文件中的`input_shape`需要填写模型导出时shape，如上述的(1, 3, 48, 160)，格式为NCHW。
+请参考[模型转换](../../../docs/cn/inference/convert_tutorial.md#1-mindocr模型)教程，使用`converter_lite`工具对MindIR模型进行离线转换。
 
 **4. 执行推理**
 
@@ -392,11 +391,8 @@ python tools/export.py --model_name_or_config configs/rec/master/master_resnet31
 ```shell
 python infer.py \
     --input_images_dir=/your_path_to/test_images \
-    --device=Ascend \
-    --device_id=0 \
     --rec_model_path=your_path_to/output.mindir \
     --rec_model_name_or_config=../../configs/rec/master/master_resnet31.yaml \
-    --backend=lite \
     --res_save_dir=results_dir
 ```
 

--- a/configs/rec/rare/README.md
+++ b/configs/rec/rare/README.md
@@ -383,8 +383,7 @@ Please refer to [Environment Installation](../../../docs/en/inference/environmen
 **3. Model Conversion**
 
 Please refer to [Model Conversion](../../../docs/en/inference/convert_tutorial.md#1-mindocr-models),
-and use the `converter_lite` tool for offline conversion of the MindIR file, where the `input_shape` in `configFile` needs to be filled in with the value from MindIR export,
-as mentioned above (1, 3, 32, 100), and the format is NCHW.
+and use the `converter_lite` tool for offline conversion of the MindIR file.
 
 **4. Inference**
 
@@ -393,11 +392,8 @@ Assuming that you obtain output.mindir after model conversion, go to the `deploy
 ```shell
 python infer.py \
     --input_images_dir=/your_path_to/test_images \
-    --device=Ascend \
-    --device_id=0 \
     --rec_model_path=your_path_to/output.mindir \
     --rec_model_name_or_config=../../configs/rec/rare/rare_resnet34.yaml \
-    --backend=lite \
     --res_save_dir=results_dir
 ```
 

--- a/configs/rec/rare/README_CN.md
+++ b/configs/rec/rare/README_CN.md
@@ -386,8 +386,7 @@ python tools/export.py --model_name_or_config configs/rec/rare/rare_resnet34.yam
 
 **3. 模型转换**
 
-请参考[模型转换](../../../docs/cn/inference/convert_tutorial.md#1-mindocr模型)教程，使用`converter_lite`工具对MindIR模型进行离线转换，
-其中`configFile`文件中的`input_shape`需要填写模型导出时shape，如上述的(1, 3, 32, 100)，格式为NCHW。
+请参考[模型转换](../../../docs/cn/inference/convert_tutorial.md#1-mindocr模型)教程，使用`converter_lite`工具对MindIR模型进行离线转换。
 
 **4. 执行推理**
 
@@ -396,11 +395,8 @@ python tools/export.py --model_name_or_config configs/rec/rare/rare_resnet34.yam
 ```shell
 python infer.py \
     --input_images_dir=/your_path_to/test_images \
-    --device=Ascend \
-    --device_id=0 \
     --rec_model_path=your_path_to/output.mindir \
     --rec_model_name_or_config=../../configs/rec/rare/rare_resnet34.yaml \
-    --backend=lite \
     --res_save_dir=results_dir
 ```
 

--- a/configs/rec/svtr/README.md
+++ b/configs/rec/svtr/README.md
@@ -400,8 +400,7 @@ Please refer to [Environment Installation](../../../docs/en/inference/environmen
 **3. Model Conversion**
 
 Please refer to [Model Conversion](../../../docs/en/inference/convert_tutorial.md#1-mindocr-models),
-and use the `converter_lite` tool for offline conversion of the MindIR file, where the `input_shape` in `configFile` needs to be filled in with the value from MindIR export,
-as mentioned above (1, 3, 64, 256), and the format is NCHW.
+and use the `converter_lite` tool for offline conversion of the MindIR file.
 
 **4. Inference**
 
@@ -410,11 +409,8 @@ Assuming that you obtain output.mindir after model conversion, go to the `deploy
 ```shell
 python infer.py \
     --input_images_dir=/your_path_to/test_images \
-    --device=Ascend \
-    --device_id=0 \
     --rec_model_path=your_path_to/output.mindir \
     --rec_model_name_or_config=../../configs/rec/svtr/svtr_tiny.yaml \
-    --backend=lite \
     --res_save_dir=results_dir
 ```
 

--- a/configs/rec/svtr/README_CN.md
+++ b/configs/rec/svtr/README_CN.md
@@ -395,8 +395,7 @@ python tools/export.py --model_name_or_config configs/rec/svtr/svtr_tiny.yaml --
 
 **3. 模型转换**
 
-请参考[模型转换](../../../docs/cn/inference/convert_tutorial.md#1-mindocr模型)教程，使用`converter_lite`工具对MindIR模型进行离线转换，
-其中`configFile`文件中的`input_shape`需要填写模型导出时shape，如上述的(1, 3, 64, 256)，格式为NCHW。
+请参考[模型转换](../../../docs/cn/inference/convert_tutorial.md#1-mindocr模型)教程，使用`converter_lite`工具对MindIR模型进行离线转换。
 
 **4. 执行推理**
 
@@ -405,11 +404,8 @@ python tools/export.py --model_name_or_config configs/rec/svtr/svtr_tiny.yaml --
 ```shell
 python infer.py \
     --input_images_dir=/your_path_to/test_images \
-    --device=Ascend \
-    --device_id=0 \
     --rec_model_path=your_path_to/output.mindir \
     --rec_model_name_or_config=../../configs/rec/svtr/svtr_tiny.yaml \
-    --backend=lite \
     --res_save_dir=results_dir
 ```
 

--- a/configs/rec/visionlan/README.md
+++ b/configs/rec/visionlan/README.md
@@ -275,29 +275,15 @@ If you haven't downloaded MindSpore Lite, please download it via this [link](htt
 
 `converter_lite` tool is an executable program under `mindspore-lite-{version}-linux-x64/tools/converter/converter`. Using `converter_lite`, we can convert the MindIR file to MindSpore Lite MindIR file.
 
-First, we need to prepare a configuration file `config.txt`:
-```text
-[ascend_context]
-input_format=NCHW
-input_shape=args0:[1,3,64,256]
-```
-The first line `[ascend_context]` indicates that the subsequent content is the relevant setting of the Ascend backend. Usually, when creating a configuration file, this line must be added to indicate the relevant setting content of the Ascend backend;
-
-The second line `input_format=NCHW` indicates that the input format of the model is [batch_size, channel_num, Height, Width];
-
-The third line `input_shape=args0:[1,3,64,256]` means that the variable name of the model input is `args0`, and the shape of `args0` is `[1,3,64,256]`; If other models or backbones are used, the setting of shape needs to refer to the data shape column in the model support list;
-
-After preparing `config.txt`, we can run the following command:
+Run the following command:
 
 ```bash
 converter_lite \
      --saveType=MINDIR \
-     --NoFusion=false \
      --fmk=MINDIR \
-     --device=Ascend \
+     --optimize=ascend_oriented \
      --modelFile=path/to/mindir/file \
-     --outputFile=visionlan_resnet45_lite \
-     --configFile=config.txt
+     --outputFile=visionlan_resnet45_lite
 ```
 
 Running this command will save a `visionlan_resnet45_lite.mindir` under the current working directory. This is the MindSpore Lite MindIR file that we can run inference with on the Ascend310 or 310P platform. You can also define a different file name by changing the `--outputFile` argument.
@@ -324,8 +310,6 @@ We run inference with the `visionlan_resnet45_lite.mindir` file with the command
 ```bash
 python deploy/py_infer/infer.py  \
     --input_images_dir=/path/to/svt_dataset/test  \
-    --device_id=0  \
-    --parallel_num=1  \
     --rec_model_path=/path/to/visionlan_resnet45_lite.mindir  \
     --rec_model_name_or_config=configs/rec/visionlan/visionlan_resnet45_LA.yaml \
     --res_save_dir=rec_svt

--- a/configs/rec/visionlan/README_CN.md
+++ b/configs/rec/visionlan/README_CN.md
@@ -254,28 +254,15 @@ python tools/export.py --model_name_or_config visionlan_resnet45 --data_shape 64
 
 `converter_lite`工具是`mindspore-lite-{version}-linux-x64/tools/converter/converter`下的可执行程序。使用`converter_lite`，我们可以将 `MindIR`文件转换为`MindSpore Lite MindIR`文件。
 
-首先，我们需要准备一个配置文件`config.txt`：
-```text
-[ascend_context]
-input_format=NCHW
-input_shape=args0:[1,3,64,256]
-```
-第一行`[ascend_context]`表示后续内容是`Ascend`后端的相关设置。通常，在创建配置文件时，必须添加此行以指示 Ascend 后端的相关设置内容；
+以运行以下命令：
 
-第二行`input_format=NCHW`表示模型的输入格式为`[batch_size, channel_num, Height, Width]`；
-
-第三行`input_shape=args0:[1,3,64,256]`表示模型输入的变量名为`args0`，`args0`的形状为`[1,3,64,256]`；如果使用其他模型或骨干网络，则形状的设置需要参考模型支持列表中的数据形状列；
-
-准备好`config.txt`后，我们可以运行以下命令：
 ```bash
 converter_lite \
      --saveType=MINDIR \
-     --NoFusion=false \
      --fmk=MINDIR \
-     --device=Ascend \
+     --optimize=ascend_oriented \
      --modelFile=path/to/mindir/file \
-     --outputFile=visionlan_resnet45_lite \
-     --configFile=config.txt
+     --outputFile=visionlan_resnet45_lite
 ```
 运行此命令将在当前工作目录下保存一个`visionlan_resnet45_lite.mindir`文件。这是我们可以在`Ascend310`或`310P`平台上进行推理的`MindSpore Lite MindIR`文件。您还可以通过更改`--outputFile`参数来定义不同的文件名。
 
@@ -297,8 +284,6 @@ svt_dataset
 ```bash
 python deploy/py_infer/infer.py  \
     --input_images_dir=/path/to/svt_dataset/test  \
-    --device_id=0  \
-    --parallel_num=1  \
     --rec_model_path=/path/to/visionlan_resnet45_lite.mindir  \
     --rec_model_name_or_config=configs/rec/visionlan/visionlan_resnet45_LA.yaml \
     --res_save_dir=rec_svt

--- a/deploy/py_infer/src/configs/det/mmocr/fcenet_resnet50_fpn_1500e_icdar2015.yaml
+++ b/deploy/py_infer/src/configs/det/mmocr/fcenet_resnet50_fpn_1500e_icdar2015.yaml
@@ -6,6 +6,7 @@ postprocess:
   alpha: 1.2
   beta: 1.0
   score_thr: 0.3
+  from_mmocr: True
 
 
 eval:

--- a/deploy/py_infer/src/data_process/postprocess/det_east_postprocess.py
+++ b/deploy/py_infer/src/data_process/postprocess/det_east_postprocess.py
@@ -9,12 +9,12 @@ import numpy as np
 mindocr_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../../.."))
 sys.path.insert(0, mindocr_path)
 
-from mindocr.postprocess import det_east_postprocess  # noqa
+from mindocr.postprocess.det_base_postprocess import DetBasePostprocess  # noqa
 
 __all__ = ["EASTPostprocess"]
 
 
-class EASTPostprocess(det_east_postprocess.EASTPostprocess):
+class EASTPostprocess(DetBasePostprocess):
     """
     The post process for EAST, adapted to paddleocr.
     """
@@ -25,26 +25,15 @@ class EASTPostprocess(det_east_postprocess.EASTPostprocess):
         nms_thresh=0.2,
         box_type="quad",
         rescale_fields=["polys"],
-        # for paddleocr east postprocess
         cover_thresh=0.1,
-        from_ppocr=False,
-        **kwargs
     ):
-        super().__init__(score_thresh, nms_thresh, box_type, rescale_fields)
+        super().__init__(box_type=box_type, rescale_fields=rescale_fields)
+        self._score_thresh = score_thresh
+        self._nms_thresh = nms_thresh
+        self._cover_thresh = cover_thresh
+        assert box_type == "quad"
 
-        if from_ppocr:
-            self._cover_thresh = cover_thresh
-            assert box_type == "quad"
-
-        self._from_ppocr = from_ppocr
-
-    def _postprocess(self, pred, **kwargs):
-        if not self._from_ppocr:
-            return super()._postprocess(pred)
-        else:
-            return self._postprocess_ppocr(pred)
-
-    def _postprocess_ppocr(self, pred: tuple):
+    def _postprocess(self, pred: tuple, **kwargs):
         geo_list = pred[0]
         score_list = pred[1]
 

--- a/docs/cn/inference/convert_tutorial.md
+++ b/docs/cn/inference/convert_tutorial.md
@@ -41,9 +41,8 @@ python tools/export.py --model_name_or_config configs/rec/crnn/crnn_resnet34.yam
 ```shell
 converter_lite \
     --saveType=MINDIR \
-    --NoFusion=false \
     --fmk=MINDIR \
-    --device=Ascend \
+    --optimize=ascend_oriented \
     --modelFile=input.mindir \
     --outputFile=output \
     --configFile=config.txt
@@ -190,9 +189,8 @@ paddle2onnx \
 ```shell
 converter_lite \
     --saveType=MINDIR \
-    --NoFusion=false \
     --fmk=ONNX \
-    --device=Ascend \
+    --optimize=ascend_oriented \
     --modelFile=det_db.onnx \
     --outputFile=det_db_output \
     --configFile=config.txt

--- a/docs/cn/inference/inference_quickstart.md
+++ b/docs/cn/inference/inference_quickstart.md
@@ -15,6 +15,7 @@
 | [PSENet](https://github.com/mindspore-lab/mindocr/tree/main/configs/det/psenet) | ResNet-152  | en      | IC15   | 82.50  | 2.52  | (1,3,1472,2624) | [yaml](https://github.com/mindspore-lab/mindocr/tree/main/configs/det/psenet/pse_r152_icdar15.yaml)      | [ckpt](https://download.mindspore.cn/toolkits/mindocr/psenet/psenet_resnet152_ic15-6058a798.ckpt) \| [mindir](https://download.mindspore.cn/toolkits/mindocr/psenet/psenet_resnet152_ic15-6058a798-0d755205.mindir)         |
 |                                                                                 | ResNet-50  | en      | IC15   | 81.37  | 10.16  | (1,3,736,1312) | [yaml](https://github.com/mindspore-lab/mindocr/tree/main/configs/det/psenet/pse_r50_icdar15.yaml)      | [ckpt](https://download.mindspore.cn/toolkits/mindocr/psenet/psenet_resnet50_ic15-7e36cab9.ckpt) \| [mindir](https://download.mindspore.cn/toolkits/mindocr/psenet/psenet_resnet50_ic15-7e36cab9-cfd2ee6c.mindir)         |
 |                                                                                 | MobileNetV3  | en      | IC15   | 70.56  | 10.38  | (1,3,736,1312) | [yaml](https://github.com/mindspore-lab/mindocr/tree/main/configs/det/psenet/pse_mv3_icdar15.yaml)      | [ckpt](https://download.mindspore.cn/toolkits/mindocr/psenet/psenet_mobilenetv3_ic15-bf2c1907.ckpt) \| [mindir](https://download.mindspore.cn/toolkits/mindocr/psenet/psenet_mobilenetv3_ic15-bf2c1907-da7cfe09.mindir)         |
+| [FCENet](https://github.com/mindspore-lab/mindocr/tree/main/configs/det/fcenet) | ResNet50 | en | IC15 | 78.94 | 14.59 | (1,3,736,1280) | [yaml](https://github.com/mindspore-lab/mindocr/blob/main/configs/det/fcenet/fce_icdar15.yaml) | [ckpt](https://download.mindspore.cn/toolkits/mindocr/fcenet/fcenet_resnet50-43857f7f.ckpt) \| [mindir](https://download.mindspore.cn/toolkits/mindocr/fcenet/fcenet_resnet50-43857f7f-dad7dfcc.mindir) |
 
 #### 1.2 文本识别
 
@@ -26,8 +27,8 @@
 | [SVTR](https://github.com/mindspore-lab/mindocr/tree/main/configs/rec/svtr) | Tiny        | Default                                                                                          | IC15  | 79.92 | 338.04 | (1,3,64,256)  | [yaml](https://github.com/mindspore-lab/mindocr/blob/main/configs/rec/svtr/svtr_tiny.yaml)    | [ckpt](https://download.mindspore.cn/toolkits/mindocr/svtr/svtr_tiny-950be1c3.ckpt) \| [mindir](https://download.mindspore.cn/toolkits/mindocr/svtr/svtr_tiny-950be1c3-86ece8c8.mindir)    |
 | [Rare](https://github.com/mindspore-lab/mindocr/tree/main/configs/rec/rare) | ResNet34_vd | Default                                                                                          | IC15  | 69.47 | 273.23 | (1,3,32,100) | [yaml](https://github.com/mindspore-lab/mindocr/blob/main/configs/rec/rare/rare_resnet34.yaml)    | [ckpt](https://download.mindspore.cn/toolkits/mindocr/rare/rare_resnet34-309dc63e.ckpt) \| [mindir](https://download.mindspore.cn/toolkits/mindocr/rare/rare_resnet34_ascend-309dc63e-b96c2a4b.mindir)    |
 |                                                                             | ResNet34_vd | [ch_dict.txt](https://github.com/mindspore-lab/mindocr/tree/main/mindocr/utils/dict/ch_dict.txt) | /     | /      | /      | (1,3,32,320) | [yaml](https://github.com/mindspore-lab/mindocr/blob/main/configs/rec/rare/rare_resnet34_ch.yaml) | [ckpt](https://download.mindspore.cn/toolkits/mindocr/rare/rare_resnet34_ch-5f3023e2.ckpt) \| [mindir](https://download.mindspore.cn/toolkits/mindocr/rare/rare_resnet34_ch_ascend-5f3023e2-11f0d554.mindir) |
-| [RobustScanner](https://github.com/mindspore-lab/mindocr/tree/main/configs/rec/robustscanner) | ResNet-31 | [en_dict90.txt](https://github.com/mindspore-lab/mindocr/blob/main/mindocr/utils/dict/en_dict90.txt) | IC15 | 73.71 | 22.30 | (1, 3, 48, 160) | [yaml](https://github.com/mindspore-lab/mindocr/blob/main/configs/rec/robustscanner/robustscanner_resnet31.yaml) | [ckpt](https://download.mindspore.cn/toolkits/mindocr/robustscanner/robustscanner_resnet31-f27eab37.ckpt) \| [mindir](https://download.mindspore.cn/toolkits/mindocr/robustscanner/robustscanner_resnet31-f27eab37-158bde10.mindir) |
-| [VisionLAN](https://github.com/mindspore-lab/mindocr/tree/main/configs/rec/visionlan) | ResNet-45 | Default |  IC15 |  80.07  |  321.37 | (1, 3, 64, 256) | [yaml(LA)](https://github.com/mindspore-lab/mindocr/blob/main/configs/rec/visionlan/visionlan_resnet45_LA.yaml) | [ckpt(LA)](https://download.mindspore.cn/toolkits/mindocr/visionlan/visionlan_resnet45_LA-e9720d9e.ckpt) \| [mindir(LA)](https://download.mindspore.cn/toolkits/mindocr/visionlan/visionlan_resnet45_LA-e9720d9e-71b38d2d.mindir) |
+| [RobustScanner](https://github.com/mindspore-lab/mindocr/tree/main/configs/rec/robustscanner) | ResNet-31 | [en_dict90.txt](https://github.com/mindspore-lab/mindocr/blob/main/mindocr/utils/dict/en_dict90.txt) | IC15 | 73.71 | 22.30 | (1,3,48,160) | [yaml](https://github.com/mindspore-lab/mindocr/blob/main/configs/rec/robustscanner/robustscanner_resnet31.yaml) | [ckpt](https://download.mindspore.cn/toolkits/mindocr/robustscanner/robustscanner_resnet31-f27eab37.ckpt) \| [mindir](https://download.mindspore.cn/toolkits/mindocr/robustscanner/robustscanner_resnet31-f27eab37-158bde10.mindir) |
+| [VisionLAN](https://github.com/mindspore-lab/mindocr/tree/main/configs/rec/visionlan) | ResNet-45 | Default |  IC15 |  80.07  |  321.37 | (1,3,64,256) | [yaml(LA)](https://github.com/mindspore-lab/mindocr/blob/main/configs/rec/visionlan/visionlan_resnet45_LA.yaml) | [ckpt(LA)](https://download.mindspore.cn/toolkits/mindocr/visionlan/visionlan_resnet45_LA-e9720d9e.ckpt) \| [mindir(LA)](https://download.mindspore.cn/toolkits/mindocr/visionlan/visionlan_resnet45_LA-e9720d9e-71b38d2d.mindir) |
 
 <br></br>
 ### 2. MindOCR推理流程
@@ -76,50 +77,24 @@ python tools/export.py --model_name_or_config dbnet_resnet50 --data_shape 736 12
 
 ```--local_ckpt_path /path/to/dbnet.ckpt```参数表明需要导出的模型文件为```/path/to/dbnet.ckpt```
 
-
 - 在Ascend310或310P上使用converter_lite工具将MindIR转换为MindSpore Lite MindIR：
-
-创建`config.txt`并指定模型输入shape：
-```
-[ascend_context]
-input_format=NCHW
-input_shape=x:[1,3,736,1280]
-```
-第一行```[ascend_context]```表明后续内容为Ascend后端的相关设置，通常在创建配置文件时，必须要加上该行指明Ascend后端的相关设置内容；
-
-第二行```input_format=NCHW```表明模型的输入格式为```[batch_size, channel_num, Height, Width]```；
-
-第三行```input_shape=x:[1,3,736,1280]```，其含义为模型输入的变量名为```x```，并且```x```的shape为```[1,3,736,1280]```；若使用其他模型或骨干网络，shape的设置需要参考模型支持列表中的**data shape**列；
-
-需要注意的是该变量名```x```取决于ckpt模型导出为MindIR时的输入变量名，在当前的工具代码```tools/export.py```中，关键导出代码如下：
-```python
-ms.export(net, x, file_name=output_path, file_format="MINDIR")
-```
-```ms.export```函数的第二个参数代表模型的输入变量，其变量名为```x```，因此这里配置时采用的名称也为```x```；
-
-若将上述```tools/export.py```中的关键导出代码改为
-```python
-ms.export(net, y, file_name=output_path, file_format="MINDIR")
-```
-则第三行配置需要改成```input_shape=y:[1,3,736,1280]```。
-
-> 了解更多[配置参数](https://www.mindspore.cn/lite/docs/zh-CN/master/use/cloud_infer/converter_tool_ascend.html)
 
 执行以下命令：
 ```shell
 converter_lite \
     --saveType=MINDIR \
     --fmk=MINDIR \
-    --device=Ascend \
+    --optimize=ascend_oriented \
     --modelFile=dbnet_resnet50-c3a4aa24-fbf95c82.mindir \
-    --outputFile=dbnet_resnet50 \
-    --configFile=config.txt
+    --outputFile=dbnet_resnet50
 ```
-上述命令中```--fmk=MINDIR```表明输入模型的原始格式为MindIR，同时```—fmk```参数还支持ONNX等；
+上述命令中：
+
+```--fmk=MINDIR```表明输入模型的原始格式为MindIR，同时```—fmk```参数还支持ONNX等；
 
 ```--saveType=MINDIR```表明输出模型格式为MindIR格式；
 
-```--device=Ascend```表明转换模型时的目标设备为Ascend，若未设置则默认为CPU后端推理；
+```--optimize=ascend_oriented```表明针对Ascend设备做优化；
 
 ```--modelFile=dbnet_resnet50-c3a4aa24-fbf95c82.mindir```表明当前需要转换的模型路径为```dbnet_resnet50-c3a4aa24-fbf95c82.mindir```；
 
@@ -170,24 +145,14 @@ python deploy/eval_utils/eval_det.py \
 
 - 在Ascend310或310P上使用converter_lite工具将MindIR转换为MindSpore Lite MindIR：
 
-创建`config.txt`并指定模型输入shape：
-```
-[ascend_context]
-input_format=NCHW
-input_shape=x:[1,3,32,100]
-```
-配置参数简要说明请见上述文本检测样例。
-> 了解更多[配置参数](https://www.mindspore.cn/lite/docs/zh-CN/master/use/cloud_infer/converter_tool_ascend.html)
-
 执行以下命令：
 ```shell
 converter_lite \
     --saveType=MINDIR \
     --fmk=MINDIR \
-    --device=Ascend \
+    --optimize=ascend_oriented \
     --modelFile=crnn_resnet34-83f37f07-eb10a0c9.mindir \
-    --outputFile=crnn_resnet34vd \
-    --configFile=config.txt
+    --outputFile=crnn_resnet34vd
 ```
 上述命令执行完成后会生成`crnn_resnet34vd.mindir`模型文件；
 

--- a/docs/cn/inference/inference_thirdparty_quickstart.md
+++ b/docs/cn/inference/inference_thirdparty_quickstart.md
@@ -144,9 +144,8 @@ input_shape=x:[1,3,736,1280]
 ```shell
 converter_lite \
     --saveType=MINDIR \
-    --NoFusion=false \
     --fmk=ONNX \
-    --device=Ascend \
+    --optimize=ascend_oriented \
     --modelFile=det_db.onnx \
     --outputFile=det_db_output \
     --configFile=config.txt
@@ -162,7 +161,7 @@ converter_lite参数简要说明如下：
 |  modelFile  |    是    |                         输入模型的路径                         |                -                |    -   |                         -                        |
 | outputFile |    是    |        输出模型的路径，不需加后缀，可自动生成.mindir后缀       |                -                |    -   |                         -                        |
 | configFile |    否    | 1）可作为训练后量化配置文件路径；2）可作为扩展功能配置文件路径 |                -                |    -   |                         -                        |
-|     device     |    否    |   设置转换模型时的目标设备。若未设置，默认模型调用CPU后端推理  |  Ascend、Ascend310、Ascend310P  |    -   |                         -                        |
+|  optimize  |    否    |   设置针对设备的模型优化类型。若未设置，则不做优化  |  none、general、gpu_oriented、ascend_oriented  |    -   |                         -                        |
 
 
 > 了解更多[converter_lite](https://www.mindspore.cn/lite/docs/zh-CN/master/use/cloud_infer/converter_tool.html)
@@ -245,9 +244,8 @@ dynamic_dims=[48,520],[48,320],[48,384],[48,360],[48,394],[48,321],[48,336],[48,
 ```shell
 converter_lite \
     --saveType=MINDIR \
-    --NoFusion=false \
     --fmk=ONNX \
-    --device=Ascend \
+    --optimize=ascend_oriented \
     --modelFile=en_PP-OCRv3_rec_infer.onnx \
     --outputFile=en_PP-OCRv3_rec_infer \
     --configFile=config.txt

--- a/docs/en/inference/convert_tutorial.md
+++ b/docs/en/inference/convert_tutorial.md
@@ -40,9 +40,8 @@ Assuming the input model is input.mindir and the output model after `converter_l
 ```shell
 converter_lite \
     --saveType=MINDIR \
-    --NoFusion=false \
     --fmk=MINDIR \
-    --device=Ascend \
+    --optimize=ascend_oriented \
     --modelFile=input.mindir \
     --outputFile=output \
     --configFile=config.txt
@@ -190,9 +189,8 @@ The conversion command is as follows:
 ```shell
 converter_lite \
     --saveType=MINDIR \
-    --NoFusion=false \
     --fmk=ONNX \
-    --device=Ascend \
+    --optimize=ascend_oriented \
     --modelFile=det_db.onnx \
     --outputFile=det_db_output \
     --configFile=config.txt

--- a/docs/en/inference/inference_quickstart.md
+++ b/docs/en/inference/inference_quickstart.md
@@ -15,6 +15,7 @@
 | [PSENet](https://github.com/mindspore-lab/mindocr/tree/main/configs/det/psenet) | ResNet-152  | en      | IC15   | 82.50  | 2.52  | (1,3,1472,2624) | [yaml](https://github.com/mindspore-lab/mindocr/tree/main/configs/det/psenet/pse_r152_icdar15.yaml)      | [ckpt](https://download.mindspore.cn/toolkits/mindocr/psenet/psenet_resnet152_ic15-6058a798.ckpt) \| [mindir](https://download.mindspore.cn/toolkits/mindocr/psenet/psenet_resnet152_ic15-6058a798-0d755205.mindir)         |
 |                                                                                 | ResNet-50  | en      | IC15   | 81.37  | 10.16  | (1,3,736,1312) | [yaml](https://github.com/mindspore-lab/mindocr/tree/main/configs/det/psenet/pse_r50_icdar15.yaml)      | [ckpt](https://download.mindspore.cn/toolkits/mindocr/psenet/psenet_resnet50_ic15-7e36cab9.ckpt) \| [mindir](https://download.mindspore.cn/toolkits/mindocr/psenet/psenet_resnet50_ic15-7e36cab9-cfd2ee6c.mindir)         |
 |                                                                                 | MobileNetV3  | en      | IC15   | 70.56  | 10.38  | (1,3,736,1312) | [yaml](https://github.com/mindspore-lab/mindocr/tree/main/configs/det/psenet/pse_mv3_icdar15.yaml)      | [ckpt](https://download.mindspore.cn/toolkits/mindocr/psenet/psenet_mobilenetv3_ic15-bf2c1907.ckpt) \| [mindir](https://download.mindspore.cn/toolkits/mindocr/psenet/psenet_mobilenetv3_ic15-bf2c1907-da7cfe09.mindir)         |
+| [FCENet](https://github.com/mindspore-lab/mindocr/tree/main/configs/det/fcenet) | ResNet50 | en | IC15 | 78.94 | 14.59 | (1,3,736,1280) | [yaml](https://github.com/mindspore-lab/mindocr/blob/main/configs/det/fcenet/fce_icdar15.yaml) | [ckpt](https://download.mindspore.cn/toolkits/mindocr/fcenet/fcenet_resnet50-43857f7f.ckpt) \| [mindir](https://download.mindspore.cn/toolkits/mindocr/fcenet/fcenet_resnet50-43857f7f-dad7dfcc.mindir) |
 
 #### 1.2 Text recognition
 
@@ -26,8 +27,8 @@
 | [SVTR](https://github.com/mindspore-lab/mindocr/tree/main/configs/rec/svtr) | Tiny        | Default                                                                                          | IC15  | 79.92 | 338.04 | (1,3,64,256)  | [yaml](https://github.com/mindspore-lab/mindocr/blob/main/configs/rec/svtr/svtr_tiny.yaml)    | [ckpt](https://download.mindspore.cn/toolkits/mindocr/svtr/svtr_tiny-950be1c3.ckpt) \| [mindir](https://download.mindspore.cn/toolkits/mindocr/svtr/svtr_tiny-950be1c3-86ece8c8.mindir)    |
 | [Rare](https://github.com/mindspore-lab/mindocr/tree/main/configs/rec/rare) | ResNet34_vd | Default                                                                                          | IC15  | 69.47 | 273.23 | (1,3,32,100) | [yaml](https://github.com/mindspore-lab/mindocr/blob/main/configs/rec/rare/rare_resnet34.yaml)    | [ckpt](https://download.mindspore.cn/toolkits/mindocr/rare/rare_resnet34-309dc63e.ckpt) \| [mindir](https://download.mindspore.cn/toolkits/mindocr/rare/rare_resnet34_ascend-309dc63e-b96c2a4b.mindir)    |
 |                                                                             | ResNet34_vd | [ch_dict.txt](https://github.com/mindspore-lab/mindocr/tree/main/mindocr/utils/dict/ch_dict.txt) | /     | /      | /      | (1,3,32,320) | [yaml](https://github.com/mindspore-lab/mindocr/blob/main/configs/rec/rare/rare_resnet34_ch.yaml) | [ckpt](https://download.mindspore.cn/toolkits/mindocr/rare/rare_resnet34_ch-5f3023e2.ckpt) \| [mindir](https://download.mindspore.cn/toolkits/mindocr/rare/rare_resnet34_ch_ascend-5f3023e2-11f0d554.mindir) |
-| [RobustScanner](https://github.com/mindspore-lab/mindocr/tree/main/configs/rec/robustscanner) | ResNet-31 | [en_dict90.txt](https://github.com/mindspore-lab/mindocr/blob/main/mindocr/utils/dict/en_dict90.txt) | IC15 | 73.71 | 22.30 | (1, 3, 48, 160) | [yaml](https://github.com/mindspore-lab/mindocr/blob/main/configs/rec/robustscanner/robustscanner_resnet31.yaml) | [ckpt](https://download.mindspore.cn/toolkits/mindocr/robustscanner/robustscanner_resnet31-f27eab37.ckpt) \| [mindir](https://download.mindspore.cn/toolkits/mindocr/robustscanner/robustscanner_resnet31-f27eab37-158bde10.mindir) |
-| [VisionLAN](https://github.com/mindspore-lab/mindocr/tree/main/configs/rec/visionlan) | ResNet-45 | Default |  IC15 |  80.07  |  321.37 | (1, 3, 64, 256) | [yaml(LA)](https://github.com/mindspore-lab/mindocr/blob/main/configs/rec/visionlan/visionlan_resnet45_LA.yaml) | [ckpt(LA)](https://download.mindspore.cn/toolkits/mindocr/visionlan/visionlan_resnet45_LA-e9720d9e.ckpt) \| [mindir(LA)](https://download.mindspore.cn/toolkits/mindocr/visionlan/visionlan_resnet45_LA-e9720d9e-71b38d2d.mindir) |
+| [RobustScanner](https://github.com/mindspore-lab/mindocr/tree/main/configs/rec/robustscanner) | ResNet-31 | [en_dict90.txt](https://github.com/mindspore-lab/mindocr/blob/main/mindocr/utils/dict/en_dict90.txt) | IC15 | 73.71 | 22.30 | (1,3,48,160) | [yaml](https://github.com/mindspore-lab/mindocr/blob/main/configs/rec/robustscanner/robustscanner_resnet31.yaml) | [ckpt](https://download.mindspore.cn/toolkits/mindocr/robustscanner/robustscanner_resnet31-f27eab37.ckpt) \| [mindir](https://download.mindspore.cn/toolkits/mindocr/robustscanner/robustscanner_resnet31-f27eab37-158bde10.mindir) |
+| [VisionLAN](https://github.com/mindspore-lab/mindocr/tree/main/configs/rec/visionlan) | ResNet-45 | Default |  IC15 |  80.07  |  321.37 | (1,3,64,256) | [yaml(LA)](https://github.com/mindspore-lab/mindocr/blob/main/configs/rec/visionlan/visionlan_resnet45_LA.yaml) | [ckpt(LA)](https://download.mindspore.cn/toolkits/mindocr/visionlan/visionlan_resnet45_LA-e9720d9e.ckpt) \| [mindir(LA)](https://download.mindspore.cn/toolkits/mindocr/visionlan/visionlan_resnet45_LA-e9720d9e-71b38d2d.mindir) |
 
 <br></br>
 ### 2. Overview of MindOCR Inference
@@ -80,49 +81,22 @@ The ```--data_shape 736 1280``` parameter indicates that the size of the model i
 
 - Use the converter_lite tool on Ascend310 or 310P to convert the MindIR to MindSpore Lite MindIR:
 
-Create `config.txt` and specify the model input shape:
-```
-[ascend_context]
-input_format=NCHW
-input_shape=x:[1,3,736,1280]
-```
-
-The first line ```[ascend_context]``` indicates that the subsequent content is the relevant setting of the Ascend backend. Usually, when creating a configuration file, this line must be added to indicate the relevant setting content of the Ascend backend;
-
-The second line ```input_format=NCHW``` indicates that the input format of the model is ```[batch_size, channel_num, Height, Width]```;
-
-The third line ```input_shape=x:[1,3,736,1280]``` means that the variable name of the model input is ```x```, and the shape of ```x``` is ```[1,3,736,1280]```; If other models or backbones are used, the setting of shape needs to refer to the **data shape** column in the model support list;
-
-It should be noted that the variable name ```x``` depends on the input variable name when the ckpt model is exported to MindIR. In the current tool codes ```tools/export.py```, the key export code is as follows:
-```python
-ms.export(net, x, file_name=output_path, file_format="MINDIR")
-```
-The second parameter of the function ```ms.export``` represents the input variable of the model, and its variable name is ```x```, so the name used in configuration here is also ```x```;
-
-If the key export code in the above ```tools/export.py``` is changed to
-```python
-ms.export(net, y, file_name=output_path, file_format="MINDIR")
-```
-Then the configuration on the third line needs to be changed to ```input_shape=y:[1,3,736,1280]```.
-
-> Learn more about [Configuration File Parameters](https://www.mindspore.cn/lite/docs/en/master/use/cloud_infer/converter_tool_ascend.html)
-
 Run the following command:
 ```shell
 converter_lite \
      --saveType=MINDIR \
-     --NoFusion=false \
      --fmk=MINDIR \
-     --device=Ascend \
+     --optimize=ascend_oriented \
      --modelFile=dbnet_resnet50-c3a4aa24-fbf95c82.mindir \
-     --outputFile=dbnet_resnet50 \
-     --configFile=config.txt
+     --outputFile=dbnet_resnet50
 ```
-In the above command ```--fmk=MINDIR``` indicates that the original format of the input model is MindIR, and the ```--fmk``` parameter also supports ONNX, etc.;
+In the above command:
+
+```--fmk=MINDIR``` indicates that the original format of the input model is MindIR, and the ```--fmk``` parameter also supports ONNX, etc.;
 
 ```--saveType=MINDIR``` indicates that the output model format is MindIR format;
 
-```--device=Ascend``` indicates that the target device when converting the model is Ascend, if not set, the default is CPU backend inferencing;
+```--optimize=ascend_oriented``` indicates that optimize for Ascend devices;
 
 ```--modelFile=dbnet_resnet50-c3a4aa24-fbf95c82.mindir``` indicates that the current model path to be converted is ```dbnet_resnet50-c3a4aa24-fbf95c82.mindir```;
 
@@ -171,26 +145,14 @@ Let's take `CRNN ResNet34_vd en` in the [model support list](#12-text-recognitio
 
 - Use the converter_lite tool on Ascend310 or 310P to convert the MindIR to MindSpore Lite MindIR:
 
-Create `config.txt` and specify the model input shape:
-```
-[ascend_context]
-input_format=NCHW
-input_shape=x:[1,3,32,100]
-```
-For a brief description of the configuration parameters, see the text detection example above.
-
-> Learn more about [Configuration File Parameters](https://www.mindspore.cn/lite/docs/en/master/use/cloud_infer/converter_tool_ascend.html)
-
 Run the following command:
 ```shell
 converter_lite \
      --saveType=MINDIR \
-     --NoFusion=false \
      --fmk=MINDIR \
-     --device=Ascend \
+     --optimize=ascend_oriented \
      --modelFile=crnn_resnet34-83f37f07-eb10a0c9.mindir \
-     --outputFile=crnn_resnet34vd \
-     --configFile=config.txt
+     --outputFile=crnn_resnet34vd
 ```
 After the above command is executed, the `crnn_resnet34vd.mindir` model file will be generated;
 

--- a/docs/en/inference/inference_thirdparty_quickstart.md
+++ b/docs/en/inference/inference_thirdparty_quickstart.md
@@ -147,9 +147,8 @@ Run the following command:
 ```shell
 converter_lite\
      --saveType=MINDIR \
-     --NoFusion=false \
      --fmk=ONNX \
-     --device=Ascend\
+     --optimize=ascend_oriented \
      --modelFile=det_db.onnx \
      --outputFile=det_db_output \
      --configFile=config.txt
@@ -165,7 +164,8 @@ A brief explanation of the converter_lite parameters is as follows:
 |  modelFile  |    Yes   |                                  Input model path                                 |                -                |    -    |                                     -                                    |
 | outputFile |    Yes   | Output model path. Do not add a suffix, ".mindir" suffix will be generated automatically. |                -                |    -    |                                     -                                    |
 | configFile |    No    |     1) Path to the quantization configuration file after training; 2) Path to the configuration file for extended functions |                -                |    -    |                                     -                                    |
-|     device     |    No    |             Set the target device for model conversion. Default is CPU.            |      Ascend, Ascend310, Ascend310P     |    -    |                                     -                                    |
+|  optimize     |    No    |   Set the model optimization type for the device. Default is none.            |      none、general、gpu_oriented、ascend_oriented     |    -    |                                     -                                    |
+
 
 > Learn more about [converter_lite](https://www.mindspore.cn/lite/docs/en/master/use/cloud_infer/converter_tool.html)
 
@@ -245,9 +245,8 @@ Run the following command:
 ```shell
 converter_lite\
      --saveType=MINDIR \
-     --NoFusion=false \
      --fmk=ONNX \
-     --device=Ascend\
+     --optimize=ascend_oriented\
      --modelFile=en_PP-OCRv3_rec_infer.onnx \
      --outputFile=en_PP-OCRv3_rec_infer \
      --configFile=config.txt

--- a/mindocr/postprocess/det_fce_postprocess.py
+++ b/mindocr/postprocess/det_fce_postprocess.py
@@ -5,6 +5,8 @@ import numpy as np
 from numpy.fft import ifft
 from shapely.geometry import Polygon
 
+from mindspore import Tensor
+
 from .det_base_postprocess import DetBasePostprocess
 
 __all__ = ["FCEPostprocess"]
@@ -302,12 +304,13 @@ class FCEPostprocess(DetBasePostprocess):
     def _postprocess(self, pred, **kwargs):
         score_maps = []
         for value in pred:
-            value = value.asnumpy()
+            if isinstance(value, Tensor):
+                value = value.asnumpy()
             cls_res = value[:, :4, :, :]
             reg_res = value[:, 4:, :, :]
             score_maps.append([cls_res, reg_res])
         polys, scores = self.get_boundary(score_maps, np.array([[0, 0, 1, 1]]))
-        return {"polys": polys, "scores": scores}
+        return {"polys": [polys], "scores": [scores]}
 
     def get_boundary(self, score_maps, shape_list):
         assert len(score_maps) == len(self.scales)


### PR DESCRIPTION
Thank you for your contribution to the MindOCR repo.
Before submitting this PR, please make sure:

- [x] You have read the [Contributing Guidelines on pull requests](https://github.com/mindspore-lab/mindcv/blob/main/CONTRIBUTING.md)
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved terminology
- [ ] You have added unit tests

## Motivation

1. 增加FCENet自研模型的推理，（将 https://github.com/mindspore-lab/mindocr/pull/543 同步过来合入）；
2. 由于一些模型的后处理，自研模型与第三方模型冲突，故而设置from_ppocr、from_mmocr字段在yaml中标记，在builder时区分加载，目前FCENet和EAST涉及该情况；
3. 修复一些文档的描述：
（1）自研模型的converter_lite去掉config参数，一般情况无需配置（第三方模型暂无法去掉，待全面支持动态shape后可去掉）；
（2）converter_lite的NoFusion和device参数已废弃，统一改为optimize；
（3）PSENet的shape之前描述错误，进行修复。
 

## Test Plan

(How should this PR be tested? Do you require special setup to run the test or repro the fixed bug?)

## Related Issues and PRs

(Is this PR part of a group of changes? Link the other relevant PRs and Issues here. Use https://help.github.com/en/articles/closing-issues-using-keywords for help on GitHub syntax)
