### PR TITLE
update mindspore and mkdocs version for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
         pip install -r requirements/dev.txt
         # MindSpore must be installed following the instruction from official web, but not from pypi.
         # That's why we exclude mindspore from requirements.txt. Does this work?
-        pip install "mindspore>=1.9,<=1.10"
+        pip install "mindspore>=1.9,<=2.1"
     - name: Lint with pre-commit
       uses: pre-commit/action@v3.0.0
     - name: Check_Cpplint

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,7 +1,5 @@
--r ../requirements.txt
-mindspore>=1.9,<=1.10
 mkdocs>=1.4.2
 mkdocs-material>=9.1.7
 mkdocstrings[python]>=0.21.2
-mkdocs-static-i18n>=0.56
+mkdocs-static-i18n==0.56
 mkdocs-include-markdown-plugin>=4.0.4


### PR DESCRIPTION
Thank you for your contribution to the MindOCR repo.
Before submitting this PR, please make sure:

- [x] You have read the [Contributing Guidelines on pull requests](https://github.com/mindspore-lab/mindcv/blob/main/CONTRIBUTING.md)
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved terminology
- [x] You have added unit tests

## Motivation

- `mkdocs-static-i18n` has [breaking updates](https://github.com/ultrabug/mkdocs-static-i18n#upgrading-from-0x-versions) recently, from version 0.56 to 1.0.0. I tried to adapt to version 1.0.0 but failed, let's keep it version 0.56.
- Update mindspore version to 2.1 for CI.
