### PR TITLE
[WIP] export dynamic shape mindir

### DIFF
--- a/mindocr/losses/det_loss.py
+++ b/mindocr/losses/det_loss.py
@@ -4,7 +4,6 @@ from typing import Tuple, Union
 
 import mindspore as ms
 import mindspore.common.dtype as mstype
-import mindspore.numpy as mnp
 from mindspore import Tensor, nn, ops
 
 __all__ = ["DBLoss", "PSEDiceLoss", "EASTLoss", "FCELoss"]
@@ -165,7 +164,7 @@ class BalancedBCELoss(nn.LossBase):
         neg_loss = (loss * negative).view(loss.shape[0], -1)
 
         neg_vals, _ = ops.sort(neg_loss)
-        neg_index = ops.stack((mnp.arange(loss.shape[0]), neg_vals.shape[1] - neg_count), axis=1)
+        neg_index = ops.stack((ops.arange(loss.shape[0], dtype=neg_count.dtype), neg_vals.shape[1] - neg_count), axis=1)
         min_neg_score = ops.expand_dims(ops.gather_nd(neg_vals, neg_index), axis=1)
 
         neg_loss_mask = (neg_loss >= min_neg_score).astype(ms.float32)  # filter values less than top k

--- a/mindocr/losses/rec_loss.py
+++ b/mindocr/losses/rec_loss.py
@@ -145,15 +145,16 @@ class VisionLANLoss(LossBase):
 class AttentionLoss(LossBase):
     def __init__(self, reduction: str = "mean", ignore_index: int = 0) -> None:
         super().__init__()
+        self.reduction = reduction
         # ignore <GO> symbol, assume it is placed at 0th index
-        self.criterion = nn.CrossEntropyLoss(reduction=reduction, ignore_index=ignore_index)
+        self.ignore_index = ignore_index
 
     def construct(self, logits: Tensor, labels: Tensor) -> Tensor:
         labels = labels[:, 1:]  # without <GO> symbol
         num_classes = logits.shape[-1]
         logits = ops.reshape(logits, (-1, num_classes))
         labels = ops.reshape(labels, (-1,))
-        return self.criterion(logits, labels)
+        return ops.cross_entropy(logits, labels, reduction=self.reduction, ignore_index=self.ignore_index)
 
 
 class SARLoss(LossBase):

--- a/mindocr/models/backbones/blocks/magca.py
+++ b/mindocr/models/backbones/blocks/magca.py
@@ -81,6 +81,8 @@ class MultiAspectGCAttention(nn.Cell):
                 nn.Conv2d(self.planes, self.inplanes, kernel_size=1, has_bias=True),
             )
 
+        self.matmul = ops.BatchMatMul()
+
     def spatial_pool(self, x: Tensor) -> Tensor:
         N, _, H, W = x.shape
         if self.pooling_type == "att":
@@ -110,7 +112,7 @@ class MultiAspectGCAttention(nn.Cell):
             # [N*headers, 1, H * W, 1]
             context_mask = ops.expand_dims(context_mask, -1)
             # [N*headers, 1, C', 1] = [N*headers, 1, C', H * W] * [N*headers, 1, H * W, 1]
-            context = ops.matmul(input_x, context_mask)
+            context = self.matmul(input_x, context_mask)
 
             # [N, headers * C', 1, 1]
             context = context.reshape(

--- a/mindocr/models/necks/fpn.py
+++ b/mindocr/models/necks/fpn.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List
 
 from mindspore import Tensor, nn, ops
 from mindspore.common.initializer import TruncatedNormal, XavierUniform
@@ -7,13 +7,8 @@ from ...utils.misc import is_ms_version_2
 from .asf import AdaptiveScaleFusion
 
 
-def _resize_nn(x: Tensor, scale: int = 0, shape: Tuple[int] = None):
-    if scale == 1 or shape == x.shape[2:]:
-        return x
-
-    if scale:
-        shape = (x.shape[2] * scale, x.shape[3] * scale)
-    return ops.ResizeNearestNeighbor(shape)(x)
+def _resize_nn(x: Tensor, shape: Tensor):
+    return ops.ResizeNearestNeighborV2()(x, shape)
 
 
 class FPN(nn.Cell):
@@ -64,10 +59,10 @@ class DBFPN(nn.Cell):
             features[i] = uc_op(features[i])
 
         for i in range(2, -1, -1):
-            features[i] += _resize_nn(features[i + 1], shape=features[i].shape[2:])
+            features[i] += _resize_nn(features[i + 1], shape=ops.dyn_shape(features[i])[2:])
 
         for i, out in enumerate(self.out):
-            features[i] = _resize_nn(out(features[i]), shape=features[0].shape[2:])
+            features[i] = _resize_nn(out(features[i]), shape=ops.dyn_shape(features[0])[2:])
 
         return self.fuse(features[::-1])  # matching the reverse order of the original work
 

--- a/mindocr/models/transforms/tps_spatial_transformer.py
+++ b/mindocr/models/transforms/tps_spatial_transformer.py
@@ -111,6 +111,8 @@ class TPSSpatialTransformer(nn.Cell):
         self.target_coordinate_repr = Tensor(target_coordinate_repr, dtype=ms.float32)
         self.target_control_points = Tensor(target_control_points, dtype=ms.float32)
 
+        self.matmul = ops.BatchMatMul()
+
     def construct(
         self, input: Tensor, source_control_points: Tensor
     ) -> Tuple[Tensor, Tensor]:
@@ -118,8 +120,8 @@ class TPSSpatialTransformer(nn.Cell):
 
         padding_matrix = ops.tile(self.padding_matrix, (batch_size, 1, 1))
         Y = ops.concat([source_control_points, padding_matrix], axis=1)
-        mapping_matrix = ops.matmul(self.inverse_kernel, Y)
-        source_coordinate = ops.matmul(self.target_coordinate_repr, mapping_matrix)
+        mapping_matrix = self.matmul(self.inverse_kernel[None, ...], Y)
+        source_coordinate = self.matmul(self.target_coordinate_repr[None, ...], mapping_matrix)
         grid = ops.reshape(
             source_coordinate,
             (-1, self.target_height, self.target_width, 2),

--- a/mindocr/models/utils/attention_cells.py
+++ b/mindocr/models/utils/attention_cells.py
@@ -120,6 +120,6 @@ class PositionalEncoding(nn.Cell):
 
     def construct(self, input_tensor: Tensor) -> Tensor:
         input_tensor = (
-            input_tensor + self.pe[:, : input_tensor.shape[1]]
+            input_tensor + self.pe[:, : ops.dyn_shape(input_tensor)[1]]
         )  # pe 1 5000 512
         return self.dropout(input_tensor)

--- a/tools/export.py
+++ b/tools/export.py
@@ -77,8 +77,12 @@ def export(model_name_or_config, data_shape, local_ckpt_path, save_dir, is_dynam
     if is_dynamic_shape:
         if model_type == "det":
             x = ms.Tensor(shape=[None, 3, None, None], dtype=ms.float32)
+        elif model_type == "rec":
+            h_map = {"master_resnet31": 48}
+            h = h_map.get(name, 32)
+            x = ms.Tensor(shape=[None, 3, h, None], dtype=ms.float32)
         else:
-            x = ms.Tensor(shape=[None, 3, 32, None], dtype=ms.float32)
+            x = ms.Tensor(shape=[None, 3, 48, 192], dtype=ms.float32)
     else:
         h, w = data_shape
         bs, c = 1, 3


### PR DESCRIPTION
Thank you for your contribution to the MindOCR repo.
Before submitting this PR, please make sure:

- [x] You have read the [Contributing Guidelines on pull requests](https://github.com/mindspore-lab/mindcv/blob/main/CONTRIBUTING.md)
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved terminology
- [ ] You have added unit tests

## Motivation

1. 动态shape导出支持

    -    支持dbnet、dbnet++、svtr、master的动态shape mindir导出，所有backbone已测试
    -    fcenet需要ops.interpolate(..., mode="area") 支持 size的动态shape，计划Q4开发

2. dbnet、dbnet++、svtr已验证动态shape版可以lite推理，master待lite修复

3. 有些修改是因为ops.matmul的动态支持不足，故而替换为ops.BatchMatMul，后续动态shape支持后可再改回去

4. 需满足：mindspore >= 2.2

- [ ]  待mindspore 2.2发布，重新验证（训练、评估、导出、推理）之后再合入

## Test Plan

(How should this PR be tested? Do you require special setup to run the test or repro the fixed bug?)

## Related Issues and PRs

(Is this PR part of a group of changes? Link the other relevant PRs and Issues here. Use https://help.github.com/en/articles/closing-issues-using-keywords for help on GitHub syntax)
