### PR TITLE
adapt 910B, modify the ctcloss to float32

### DIFF
--- a/mindocr/losses/rec_loss.py
+++ b/mindocr/losses/rec_loss.py
@@ -49,11 +49,12 @@ class CTCLoss(LossBase):
         Returns:
             loss value (Tensor)
         """
-        logit = pred
+        dtype = pred.dtype
+        logit = pred.astype(ms.float32)
         label_values = ops.reshape(label, (-1,))
 
         loss, _ = self.ctc_loss(logit, self.label_indices, label_values, self.sequence_length)
-        loss = self.get_loss(loss)
+        loss = self.get_loss(loss.astype(dtype))
         return loss
 
 


### PR DESCRIPTION
Thank you for your contribution to the MindOCR repo.
Before submitting this PR, please make sure:

- [ ] You have read the [Contributing Guidelines on pull requests](https://github.com/mindspore-lab/mindcv/blob/main/CONTRIBUTING.md)
- [ ] Your code builds clean without any errors or warnings
- [ ] You are using approved terminology
- [ ] You have added unit tests

## Motivation

The ctcloss op not surpport float16 on 910B.
In fact, the 910A is also cast to float32 on device.

## Test Plan

(How should this PR be tested? Do you require special setup to run the test or repro the fixed bug?)

## Related Issues and PRs

(Is this PR part of a group of changes? Link the other relevant PRs and Issues here. Use https://help.github.com/en/articles/closing-issues-using-keywords for help on GitHub syntax)
