### PR TITLE
disable loading backbone weights redundantly

### DIFF
--- a/configs/det/dbnet/db_r18_ctw1500.yaml
+++ b/configs/det/dbnet/db_r18_ctw1500.yaml
@@ -12,7 +12,7 @@ model:
   transform: null
   backbone:
     name: det_resnet18
-    pretrained: True
+    pretrained: False
   neck:
     name: DBFPN
     out_channels: 256

--- a/configs/det/dbnet/db_r18_mlt2017.yaml
+++ b/configs/det/dbnet/db_r18_mlt2017.yaml
@@ -12,7 +12,7 @@ model:
   transform: null
   backbone:
     name: det_resnet18
-    pretrained: True
+    pretrained: False
   neck:
     name: DBFPN
     out_channels: 256

--- a/configs/det/dbnet/db_r18_td500.yaml
+++ b/configs/det/dbnet/db_r18_td500.yaml
@@ -13,7 +13,7 @@ model:
   transform: null
   backbone:
     name: det_resnet18
-    pretrained: True
+    pretrained: False
   neck:
     name: DBFPN
     out_channels: 256

--- a/configs/det/dbnet/db_r18_totaltext.yaml
+++ b/configs/det/dbnet/db_r18_totaltext.yaml
@@ -12,7 +12,7 @@ model:
   transform: null
   backbone:
     name: det_resnet18
-    pretrained: True
+    pretrained: False
   neck:
     name: DBFPN
     out_channels: 256

--- a/configs/det/dbnet/db_r50_ctw1500.yaml
+++ b/configs/det/dbnet/db_r50_ctw1500.yaml
@@ -12,7 +12,7 @@ model:
   transform: null
   backbone:
     name: det_resnet50
-    pretrained: True
+    pretrained: False
   neck:
     name: DBFPN
     out_channels: 256

--- a/configs/det/dbnet/db_r50_mlt2017.yaml
+++ b/configs/det/dbnet/db_r50_mlt2017.yaml
@@ -12,7 +12,7 @@ model:
   transform: null
   backbone:
     name: det_resnet50
-    pretrained: True
+    pretrained: False
   neck:
     name: DBFPN
     out_channels: 256

--- a/configs/det/dbnet/db_r50_td500.yaml
+++ b/configs/det/dbnet/db_r50_td500.yaml
@@ -13,7 +13,7 @@ model:
   transform: null
   backbone:
     name: det_resnet50
-    pretrained: True
+    pretrained: False
   neck:
     name: DBFPN
     out_channels: 256

--- a/configs/det/dbnet/db_r50_totaltext.yaml
+++ b/configs/det/dbnet/db_r50_totaltext.yaml
@@ -12,7 +12,7 @@ model:
   transform: null
   backbone:
     name: det_resnet50
-    pretrained: True
+    pretrained: False
   neck:
     name: DBFPN
     out_channels: 256


### PR DESCRIPTION
Thank you for your contribution to the MindOCR repo.
Before submitting this PR, please make sure:

- [ ] You have read the [Contributing Guidelines on pull requests](https://github.com/mindspore-lab/mindcv/blob/main/CONTRIBUTING.md)
- [ ] Your code builds clean without any errors or warnings
- [ ] You are using approved terminology
- [ ] You have added unit tests

## Motivation

Set `model.backbone.pretrained` to False if `model.pretrained` has been set to avoid loading backbone pretrained weights redundantly.

## Test Plan

(How should this PR be tested? Do you require special setup to run the test or repro the fixed bug?)

## Related Issues and PRs

(Is this PR part of a group of changes? Link the other relevant PRs and Issues here. Use https://help.github.com/en/articles/closing-issues-using-keywords for help on GitHub syntax)
