### PR TITLE
Fix high cpu consumption when queue is empty

### DIFF
--- a/deploy/py_infer/src/infer_args.py
+++ b/deploy/py_infer/src/infer_args.py
@@ -41,6 +41,13 @@ def get_args():
     parser.add_argument(
         "--precision_mode", type=str, default=None, choices=["fp16", "fp32"], required=False, help="Precision mode."
     )
+    parser.add_argument(
+        "--node_fetch_interval",
+        type=float,
+        default=0,
+        required=False,
+        help="Interval(seconds) that each node fetch data from queue.",
+    )
 
     parser.add_argument("--det_model_path", type=str, required=False, help="Detection model file path.")
     parser.add_argument(

--- a/deploy/py_infer/src/parallel/framework/module_base.py
+++ b/deploy/py_infer/src/parallel/framework/module_base.py
@@ -50,6 +50,7 @@ class ModuleBase(object):
             if stop_manager.full():
                 break
             if self.input_queue.empty():
+                time.sleep(self.args.node_fetch_interval)
                 continue
             else:
                 data = self.input_queue.get(block=True)


### PR DESCRIPTION
Thank you for your contribution to the MindOCR repo.
Before submitting this PR, please make sure:

- [x] You have read the [Contributing Guidelines on pull requests](https://github.com/mindspore-lab/mindcv/blob/main/CONTRIBUTING.md)
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved terminology
- [x] You have added unit tests

## Motivation
当各node监听的queue为空，不加等待的限制，持续频繁访问队列是否非空，导致大量cpu资源空转：
 - 空转时，总cpu开销约为1100%（若起了11个node进程，每个node占用100%cpu开销）
 - `src/parallel/framework/module_base.py: 52`，`empty()`占比91.9%，并随queue为空的时间增加，占比进一步拉大

修改后
 - 空转时，总cpu开销小于5%，当`node_fetch_interval`为0.001时，即每1ms询问一次
 - 满转时，即图片持续喂入时，端到端性能劣化约3%，当`node_fetch_interval`为0.001时。该劣化可以设置`node_fetch_interval`为0恢复。

## Test Plann

(How should this PR be tested? Do you require special setup to run the test or repro the fixed bug?)

## Related Issues and PRs

(Is this PR part of a group of changes? Link the other relevant PRs and Issues here. Use https://help.github.com/en/articles/closing-issues-using-keywords for help on GitHub syntax)
