### PR TITLE
Bugfix of svtr when the input is FP16 for MindSpore r2.3rc1

### DIFF
--- a/mindocr/models/transforms/tps_spatial_transformer.py
+++ b/mindocr/models/transforms/tps_spatial_transformer.py
@@ -10,7 +10,8 @@ from mindspore import Tensor
 
 
 def grid_sample(input: Tensor, grid: Tensor, canvas: Optional[Tensor] = None) -> Tensor:
-    output = ops.grid_sample(input, grid)
+    out_type = input.dtype
+    output = ops.grid_sample(input.astype(ms.float64), grid.astype(ms.float64)).astype(out_type)
     if canvas is None:
         return output
     else:


### PR DESCRIPTION
Thank you for your contribution to the MindOCR repo.
Before submitting this PR, please make sure:

- [ ] You have read the [Contributing Guidelines on pull requests](https://github.com/mindspore-lab/mindcv/blob/main/CONTRIBUTING.md)
- [ ] Your code builds clean without any errors or warnings
- [ ] You are using approved terminology
- [ ] You have added unit tests

## Motivation

解决已知问题：当amp_level = 'O2'时，即网络输入为FP16时，grid_sample有计算问题。因此将算子输入手动转换到FP64计算。
临时规避方案，待r2.3.0修复grid_sample计算问题后，应回退该PR。
Solve known issues: When amp_level = 'O2', that is, when the network input is FP16, grid_sample has calculation problems. Therefore, the input is manually cast to FP64.

(Write your motivation for proposed changes here.)

## Test Plan

(How should this PR be tested? Do you require special setup to run the test or repro the fixed bug?)

## Related Issues and PRs

(Is this PR part of a group of changes? Link the other relevant PRs and Issues here. Use https://help.github.com/en/articles/closing-issues-using-keywords for help on GitHub syntax)
