### PR TITLE
310p export bug fix

### DIFF
--- a/mindocr/models/backbones/rec_svtr.py
+++ b/mindocr/models/backbones/rec_svtr.py
@@ -473,7 +473,9 @@ class SVTRNet(nn.Cell):
 
         if use_pos_embed:
             self.pos_embed = Parameter(
-                ops.zeros((1, num_patches, embed_dim[0]), ms.float32)
+                Tensor(
+                    np.zeros((1, num_patches, embed_dim[0]), np.float32), dtype=ms.float32
+                )
             )
         else:
             self.pos_embed = None

--- a/mindocr/models/transforms/stn.py
+++ b/mindocr/models/transforms/stn.py
@@ -71,7 +71,7 @@ class STN(nn.Cell):
         elif self.activation == "sigmoid":
             ctrl_points = -np.log(1.0 / ctrl_points - 1.0)
         ctrl_points = Tensor(ctrl_points)
-        fc2_bias = ops.reshape(ctrl_points, (-1,))
+        fc2_bias = Tensor(np.reshape(ctrl_points, (-1,)))
         return fc2_bias
 
     def construct(self, x: Tensor) -> Tuple[Tensor, Tensor]:

--- a/mindocr/models/transforms/stn.py
+++ b/mindocr/models/transforms/stn.py
@@ -70,7 +70,6 @@ class STN(nn.Cell):
             pass
         elif self.activation == "sigmoid":
             ctrl_points = -np.log(1.0 / ctrl_points - 1.0)
-        ctrl_points = Tensor(ctrl_points)
         fc2_bias = Tensor(np.reshape(ctrl_points, (-1,)))
         return fc2_bias
 

--- a/mindocr/models/transforms/tps_spatial_transformer.py
+++ b/mindocr/models/transforms/tps_spatial_transformer.py
@@ -108,7 +108,7 @@ class TPSSpatialTransformer(nn.Cell):
 
         # register precomputed matrices
         self.inverse_kernel = Tensor(inverse_kernel, dtype=ms.float32)
-        self.padding_matrix = ops.zeros((1, 3, 2), ms.float32)
+        self.padding_matrix = Tensor(np.zeros((1, 3, 2), np.float32), dtype=ms.float32)
         self.target_coordinate_repr = Tensor(target_coordinate_repr, dtype=ms.float32)
         self.target_control_points = Tensor(target_control_points, dtype=ms.float32)
 
@@ -119,8 +119,8 @@ class TPSSpatialTransformer(nn.Cell):
 
         padding_matrix = ops.tile(self.padding_matrix, (batch_size, 1, 1))
         Y = ops.concat([source_control_points, padding_matrix], axis=1)
-        mapping_matrix = ops.matmul(self.inverse_kernel, Y)
-        source_coordinate = ops.matmul(self.target_coordinate_repr, mapping_matrix)
+        mapping_matrix = ops.matmul(self.inverse_kernel.expand_dims(0), Y)
+        source_coordinate = ops.matmul(self.target_coordinate_repr.expand_dims(0), mapping_matrix)
         grid = ops.reshape(
             source_coordinate,
             (-1, self.target_height, self.target_width, 2),

--- a/mindocr/models/utils/abinet_layers.py
+++ b/mindocr/models/utils/abinet_layers.py
@@ -342,8 +342,8 @@ class PositionalEncoding(nn.Cell):
         pe[:, 0::2] = np.sin(position * div_term)
         pe[:, 1::2] = np.cos(position * div_term)
         pe = np.expand_dims(pe, 0)
+        pe = np.transpose(pe, (1, 0, 2))
         pe = ms.Tensor(pe).astype(dtype=ms.float32)
-        pe = pe.transpose(1, 0, 2)
         self.pe = ms.Parameter(pe, name="pe1", requires_grad=False)
 
     def construct(self, x):

--- a/tools/data_for_export_convert.py
+++ b/tools/data_for_export_convert.py
@@ -411,7 +411,7 @@ data_export_static_model = {
     "master_resnet31": {"model_name": "master_resnet31", "data_shape_h_w": [32, 100]},
     "cls_mobilenet_v3_small_100_model": {"model_name": "cls_mobilenet_v3_small_100_model", "data_shape_h_w": [48, 192]},
     "crnn_resnet34": {"model_name": "crnn_resnet34", "data_shape_h_w": [32, 100]},
-    "crnn_resnet34_ch": {"model_name": "crnn_resnet34_ch", "data_shape_h_w": [32, 100]},
+    "crnn_resnet34_ch": {"model_name": "crnn_resnet34_ch", "data_shape_h_w": [32, 320]},
     "crnn_vgg7": {"model_name": "crnn_vgg7", "data_shape_h_w": [32, 100]},
     "dbnet_mobilenetv3": {"model_name": "dbnet_mobilenetv3", "data_shape_h_w": [736, 1280]},
     "dbnet_resnet18": {"model_name": "dbnet_resnet18", "data_shape_h_w": [736, 1280]},

--- a/tools/export_convert_tool.py
+++ b/tools/export_convert_tool.py
@@ -77,7 +77,7 @@ class BaseConvertModel(metaclass=ABCMeta):
             else:
                 log = f"{converted_model_path}.mindir exists and it will be overwritten if exported successfully."
                 subprocess.call(f"echo {log}".split(), stdout=self.log_handle, stderr=self.log_handle)
-                os.remove(converted_model_path)
+                os.remove(f"{converted_model_path}.mindir")
                 print(log)
         command = (
             f"{self.convert_tool} --fmk=MINDIR --modelFile={input_file} --outputFile={converted_model_path}"


### PR DESCRIPTION
Thank you for your contribution to the MindOCR repo.
Before submitting this PR, please make sure:

- [x] You have read the [Contributing Guidelines on pull requests](https://github.com/mindspore-lab/mindcv/blob/main/CONTRIBUTING.md)
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved terminology
- [x] You have added unit tests

## Motivation
310p机器ocr检测和识别模型 全量export，发现可修复的bug
1. crnn_resnet34_ch convert shape匹配不上
2. 文件存在时remove报错
3. Abinet, svtr_tiny export失败解决：
    (1) 有些ms版本在init里不能有tensor操作，一般是要先用numpy算好，再转成Tensor
    (2)矩阵乘维度对不上，没有自动广播

(Write your motivation for proposed changes here.)

## Test Plan

(How should this PR be tested? Do you require special setup to run the test or repro the fixed bug?)

## Related Issues and PRs

(Is this PR part of a group of changes? Link the other relevant PRs and Issues here. Use https://help.github.com/en/articles/closing-issues-using-keywords for help on GitHub syntax)
