### PR TITLE
fix deprecated numpy int and bool

### DIFF
--- a/mindocr/data/transforms/det_fce_transforms.py
+++ b/mindocr/data/transforms/det_fce_transforms.py
@@ -550,7 +550,7 @@ class FCENetTargets:
             # assert len(poly) == 1
             # text_instance = [[poly[i], poly[i + 1]]
             #                  for i in range(0, len(poly), 2)]
-            polygon = np.array(poly, dtype=np.int).reshape((1, -1, 2))
+            polygon = np.array(poly, dtype=np.int_).reshape((1, -1, 2))
             _, _, box_w, box_h = cv2.boundingRect(polygon)
             proportion = max(box_h, box_w) / (h + 1e-8)
 
@@ -562,7 +562,7 @@ class FCENetTargets:
             # assert len(ignore_poly) == 1
             # text_instance = [[ignore_poly[i], ignore_poly[i + 1]]
             #                  for i in range(0, len(ignore_poly), 2)]
-            polygon = np.array(ignore_poly, dtype=np.int).reshape((1, -1, 2))
+            polygon = np.array(ignore_poly, dtype=np.int_).reshape((1, -1, 2))
             _, _, box_w, box_h = cv2.boundingRect(polygon)
             proportion = max(box_h, box_w) / (h + 1e-8)
 

--- a/mindocr/data/transforms/det_transforms.py
+++ b/mindocr/data/transforms/det_transforms.py
@@ -79,7 +79,7 @@ class DetLabelEncode:
 
         boxes = self.expand_points_num(boxes)
         boxes = np.array(boxes, dtype=np.float32)
-        txt_tags = np.array(txt_tags, dtype=np.bool)
+        txt_tags = np.array(txt_tags, dtype=np.bool_)
 
         data["polys"] = boxes
         data["texts"] = txts

--- a/mindocr/postprocess/det_fce_postprocess.py
+++ b/mindocr/postprocess/det_fce_postprocess.py
@@ -143,7 +143,7 @@ def fill_hole(input_mask):
     mask = np.zeros((h + 4, w + 4), np.uint8)
 
     cv2.floodFill(canvas, mask, (0, 0), 1)
-    canvas = canvas[1 : h + 1, 1 : w + 1].astype(np.bool)
+    canvas = canvas[1 : h + 1, 1 : w + 1].astype(np.bool_)
 
     return ~canvas | input_mask
 


### PR DESCRIPTION
Thank you for your contribution to the MindOCR repo.
Before submitting this PR, please make sure:

- [x] You have read the [Contributing Guidelines on pull requests](https://github.com/mindspore-lab/mindcv/blob/main/CONTRIBUTING.md)
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved terminology
- [x] You have added unit tests

## Motivation
NumPy 1.20.0 Release Notes
Using the aliases of builtin types like np.int is deprecated
numpy.int --> numpy.int_
numpy.bool --> numpy.bool_
(Write your motivation for proposed changes here.)

## Test Plan

(How should this PR be tested? Do you require special setup to run the test or repro the fixed bug?)

## Related Issues and PRs

(Is this PR part of a group of changes? Link the other relevant PRs and Issues here. Use https://help.github.com/en/articles/closing-issues-using-keywords for help on GitHub syntax)
