### PR TITLE
Revert "set jit_level to O2 under graph mode (#705)"

### DIFF
--- a/tools/eval.py
+++ b/tools/eval.py
@@ -11,7 +11,6 @@ sys.path.insert(0, os.path.abspath(os.path.join(__dir__, "..")))
 from addict import Dict
 
 import mindspore as ms
-from mindspore._c_expression import ms_ctx_param
 from mindspore.communication import get_group_size, get_rank, init
 
 from mindocr.data import build_dataset
@@ -28,10 +27,6 @@ logger = logging.getLogger("mindocr.eval")
 def main(cfg):
     # env init
     ms.set_context(mode=cfg.system.mode)
-    if "jit_level" in ms_ctx_param.__members__ and cfg.system.mode == 0:
-        # set jit_level to O2 for better pereformance under graph mode
-        ms.set_context(jit_config={"jit_level": "O2"})
-
     if cfg.system.distribute:
         init()
         device_num = get_group_size()

--- a/tools/train.py
+++ b/tools/train.py
@@ -17,7 +17,6 @@ import yaml
 from addict import Dict
 
 import mindspore as ms
-from mindspore._c_expression import ms_ctx_param
 from mindspore.communication import get_group_size, get_rank, init
 
 from mindocr.data import build_dataset
@@ -42,10 +41,6 @@ logger = logging.getLogger("mindocr.train")
 def main(cfg):
     # init env
     ms.set_context(mode=cfg.system.mode)
-    if "jit_level" in ms_ctx_param.__members__ and cfg.system.mode == 0:
-        # set jit_level to O2 for better pereformance under graph mode
-        ms.set_context(jit_config={"jit_level": "O2"})
-
     if cfg.system.distribute:
         init()
         device_num = get_group_size()


### PR DESCRIPTION
This reverts commit 8ede9d33dded7a66c7819df497c815e0cb0a5696.

Thank you for your contribution to the MindOCR repo.
Before submitting this PR, please make sure:

- [x] You have read the [Contributing Guidelines on pull requests](https://github.com/mindspore-lab/mindcv/blob/main/CONTRIBUTING.md)
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved terminology
- [ ] You have added unit tests

## Motivation

(Write your motivation for proposed changes here.)
Revert "set jit_level to O2 under graph mode (#705)"

## Test Plan

(How should this PR be tested? Do you require special setup to run the test or repro the fixed bug?)

## Related Issues and PRs

(Is this PR part of a group of changes? Link the other relevant PRs and Issues here. Use https://help.github.com/en/articles/closing-issues-using-keywords for help on GitHub syntax)
