### PR TITLE
remove required package lanms for Windows

### DIFF
--- a/deploy/py_infer/src/data_process/postprocess/det_east_postprocess.py
+++ b/deploy/py_infer/src/data_process/postprocess/det_east_postprocess.py
@@ -1,8 +1,8 @@
 import os
 import sys
+import platform
 
 import cv2
-import lanms
 import numpy as np
 
 # add mindocr root path, and import postprocess from mindocr
@@ -10,6 +10,15 @@ mindocr_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../..
 sys.path.insert(0, mindocr_path)
 
 from mindocr.postprocess.det_base_postprocess import DetBasePostprocess  # noqa
+from mindocr.postprocess.nms_py.lanms_py import lanms_win
+
+try:
+    from lanms import merge_quadrangle_n9
+except ImportError:
+    if platform.system() == "Windows":
+        merge_quadrangle_n9 = lanms_win
+    else:
+        raise ImportError("can not import lanms or lanms_win")
 
 __all__ = ["EASTPostprocess"]
 
@@ -90,7 +99,7 @@ class EASTPostprocess(DetBasePostprocess):
         boxes[:, :8] = text_box_restored.reshape((-1, 8))
         boxes[:, 8] = score_map[xy_text[:, 0], xy_text[:, 1]]
 
-        boxes = lanms.merge_quadrangle_n9(boxes, nms_thresh)
+        boxes = merge_quadrangle_n9(boxes, nms_thresh)
 
         if boxes.shape[0] == 0:
             return []

--- a/deploy/py_infer/src/data_process/postprocess/det_east_postprocess.py
+++ b/deploy/py_infer/src/data_process/postprocess/det_east_postprocess.py
@@ -1,6 +1,6 @@
 import os
-import sys
 import platform
+import sys
 
 import cv2
 import numpy as np
@@ -10,13 +10,12 @@ mindocr_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../..
 sys.path.insert(0, mindocr_path)
 
 from mindocr.postprocess.det_base_postprocess import DetBasePostprocess  # noqa
-from mindocr.postprocess.nms_py.lanms_py import lanms_win
 
 try:
     from lanms import merge_quadrangle_n9
 except ImportError:
     if platform.system() == "Windows":
-        merge_quadrangle_n9 = lanms_win
+        from mindocr.postprocess.nms_py.lanms_py import merge_quadrangle_n9
     else:
         raise ImportError("can not import lanms or lanms_win")
 

--- a/deploy/py_infer/src/data_process/postprocess/det_sast_postprocess.py
+++ b/deploy/py_infer/src/data_process/postprocess/det_sast_postprocess.py
@@ -1,8 +1,8 @@
 import os
 import sys
 from typing import Tuple
+import platform
 
-import lanms
 import numpy as np
 
 # add mindocr root path, and import postprocess from mindocr
@@ -10,6 +10,15 @@ mindocr_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../..
 sys.path.insert(0, mindocr_path)
 
 from mindocr.postprocess import det_base_postprocess  # noqa
+from mindocr.postprocess.nms_py.lanms_py import lanms_win
+
+try:
+    from lanms import merge_quadrangle_n9
+except ImportError:
+    if platform.system() == "Windows":
+        merge_quadrangle_n9 = lanms_win
+    else:
+        raise ImportError("can not import lanms or lanms_win")
 
 __all__ = ["SASTPostprocess"]
 
@@ -223,7 +232,7 @@ class SASTPostprocess(det_base_postprocess.DetBasePostprocess):
         # restore quad
         scores, quads, xy_text = self.restore_quad(tcl_map, tcl_map_thresh, tvo_map)
         dets = np.hstack((quads, scores)).astype(np.float32, copy=False)
-        dets = lanms.merge_quadrangle_n9(dets, self.nms_thresh)
+        dets = merge_quadrangle_n9(dets, self.nms_thresh)
         if dets.shape[0] == 0:
             return []
         quads = dets[:, :-1].reshape(-1, 4, 2)

--- a/deploy/py_infer/src/data_process/postprocess/det_sast_postprocess.py
+++ b/deploy/py_infer/src/data_process/postprocess/det_sast_postprocess.py
@@ -1,7 +1,7 @@
 import os
+import platform
 import sys
 from typing import Tuple
-import platform
 
 import numpy as np
 
@@ -10,13 +10,12 @@ mindocr_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../..
 sys.path.insert(0, mindocr_path)
 
 from mindocr.postprocess import det_base_postprocess  # noqa
-from mindocr.postprocess.nms_py.lanms_py import lanms_win
 
 try:
     from lanms import merge_quadrangle_n9
 except ImportError:
     if platform.system() == "Windows":
-        merge_quadrangle_n9 = lanms_win
+        from mindocr.postprocess.nms_py.lanms_py import merge_quadrangle_n9
     else:
         raise ImportError("can not import lanms or lanms_win")
 

--- a/mindocr/postprocess/det_east_postprocess.py
+++ b/mindocr/postprocess/det_east_postprocess.py
@@ -1,11 +1,20 @@
 import math
+import platform
 
-import lanms
 import numpy as np
 
 from mindspore import Tensor
 
+from .nms_py.lanms_py import lanms_win
 from .det_base_postprocess import DetBasePostprocess
+
+try:
+    from lanms import merge_quadrangle_n9
+except ImportError:
+    if platform.system() == "Windows":
+        merge_quadrangle_n9 = lanms_win
+    else:
+        raise ImportError("can not import lanms or lanms_win")
 
 __all__ = ["EASTPostprocess"]
 
@@ -64,7 +73,7 @@ class EASTPostprocess(DetBasePostprocess):
             boxes = np.zeros((polys_restored.shape[0], 9), dtype=np.float32)
             boxes[:, :8] = polys_restored
             boxes[:, 8] = score[xy_text[index, 0], xy_text[index, 1]]
-            boxes = lanms.merge_quadrangle_n9(boxes.astype("float32"), self._nms_thresh)
+            boxes = merge_quadrangle_n9(boxes.astype("float32"), self._nms_thresh)
             polys = boxes[:, :8].reshape(-1, 4, 2)
             scores = boxes[:, 8].reshape(-1, 1)
             polys_list.append(polys)

--- a/mindocr/postprocess/det_east_postprocess.py
+++ b/mindocr/postprocess/det_east_postprocess.py
@@ -5,14 +5,13 @@ import numpy as np
 
 from mindspore import Tensor
 
-from .nms_py.lanms_py import lanms_win
 from .det_base_postprocess import DetBasePostprocess
 
 try:
     from lanms import merge_quadrangle_n9
 except ImportError:
     if platform.system() == "Windows":
-        merge_quadrangle_n9 = lanms_win
+        from .nms_py.lanms_py import merge_quadrangle_n9
     else:
         raise ImportError("can not import lanms or lanms_win")
 

--- a/mindocr/postprocess/nms_py/lanms_py.py
+++ b/mindocr/postprocess/nms_py/lanms_py.py
@@ -45,7 +45,7 @@ def standard_nms(boxes: List[np.array], threshold: float) -> np.array:
     return np.array(filtered_boxes)
 
 
-def merge_quadrangle_n9(geometries: np.array, threshold: float = .3) -> np.array:
+def merge_quadrangle_n9(geometries: np.array, threshold: float = 0.3) -> np.array:
     """
     locality-aware NMS for Windows version
     :param: geometries: a numpy array with shape (N,9)

--- a/mindocr/postprocess/nms_py/lanms_py.py
+++ b/mindocr/postprocess/nms_py/lanms_py.py
@@ -41,16 +41,11 @@ def standard_nms(boxes: List[np.array], threshold: float) -> np.array:
     while sorted_boxes:
         max_score_box = sorted_boxes.pop(0)
         filtered_boxes.append(max_score_box)
-        remove_indexes = []
-        for i, box in enumerate(sorted_boxes):
-            if calculate_iou(max_score_box, box) > threshold:
-                remove_indexes.append(i)
-        for ind in remove_indexes[::-1]:
-            sorted_boxes.pop(ind)
+        sorted_boxes = list(filter(lambda x: calculate_iou(max_score_box, x) < threshold, sorted_boxes))
     return np.array(filtered_boxes)
 
 
-def lanms_win(geometries: np.array, threshold: float = .3) -> np.array:
+def merge_quadrangle_n9(geometries: np.array, threshold: float = .3) -> np.array:
     """
     locality-aware NMS for Windows version
     :param: geometries: a numpy array with shape (N,9)

--- a/mindocr/postprocess/nms_py/lanms_py.py
+++ b/mindocr/postprocess/nms_py/lanms_py.py
@@ -1,0 +1,71 @@
+from typing import List
+
+import numpy as np
+from shapely.geometry import Polygon
+
+
+def check_polygons_valid(polygons: List[Polygon]) -> bool:
+    return all([polygon.is_valid for polygon in polygons])
+
+
+def calculate_iou(box1: np.array, box2: np.array) -> float:
+    # convert np.array to Polygon
+    poly1 = Polygon(box1[:8].reshape((4, 2)))
+    poly2 = Polygon(box2[:8].reshape((4, 2)))
+    # if any of boxes is invalid, return False
+    if not check_polygons_valid([poly1, poly2]):
+        return 0
+    inter_area = poly1.intersection(poly2).area
+    union_area = poly1.union(poly2).area
+    # if union is 0, return 0
+    if union_area == 0:
+        return 0
+    return inter_area / union_area
+
+
+def should_merge(box1: np.array, box2: np.array, threshold: float) -> bool:
+    return calculate_iou(box1, box2) > threshold
+
+
+def weighted_merge(box1: np.array, box2: np.array) -> np.array:
+    merged_box = np.zeros(9)
+    merged_box[:8] = (box1[8] * box1[:8] + box2[8] * box2[:8]) / (box1[8] + box2[8])
+    merged_box[8] = box1[8] + box2[8]
+    return merged_box
+
+
+def standard_nms(boxes: List[np.array], threshold: float) -> np.array:
+    # initial filtered boxes list
+    filtered_boxes = []
+    sorted_boxes = sorted(boxes, key=lambda x: x[8], reverse=True)
+    while sorted_boxes:
+        max_score_box = sorted_boxes.pop(0)
+        filtered_boxes.append(max_score_box)
+        remove_indexes = []
+        for i, box in enumerate(sorted_boxes):
+            if calculate_iou(max_score_box, box) > threshold:
+                remove_indexes.append(i)
+        for ind in remove_indexes[::-1]:
+            sorted_boxes.pop(ind)
+    return np.array(filtered_boxes)
+
+
+def lanms_win(geometries: np.array, threshold: float = .3) -> np.array:
+    """
+    locality-aware NMS for Windows version
+    :param: geometries: a numpy array with shape (N,9)
+    :param: threshold: IOU threshold
+    :return: filtered bounding boxes
+    """
+    s = []
+    p = None
+    for g in geometries:
+        if (p is not None) and should_merge(g, p, threshold):
+            p = weighted_merge(g, p)
+        else:
+            if p is not None:
+                s.append(p)
+            p = g
+    if p is not None:
+        s.append(p)
+    return standard_nms(s, threshold)

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ PyYAML>=6.0
 xml-python>=0.4.3
 packaging>=23.1
 Cython
-lanms>=1.0.2
+lanms>=1.0.2; sys_platform == 'linux'
 sentencepiece>=0.1.99
 huggingface_hub>=0.16.4
 seqeval>=1.2.2

--- a/tests/ut/test_lanms_py.py
+++ b/tests/ut/test_lanms_py.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from mindocr.postprocess.nms_py.lanms_py import calculate_iou, weighted_merge, standard_nms, merge_quadrangle_n9
+from mindocr.postprocess.nms_py.lanms_py import calculate_iou, merge_quadrangle_n9, standard_nms, weighted_merge
 
 box1 = np.array([0, 0, 0, 20, 10, 20, 10, 0, 0.8])
 box2 = np.array([8, 10, 8, 50, 30, 50, 30, 10, 0.7])

--- a/tests/ut/test_lanms_py.py
+++ b/tests/ut/test_lanms_py.py
@@ -8,7 +8,6 @@ box3 = np.array([9, 10, 9, 60, 30, 60, 30, 10, 1.1])
 
 
 class TestLanmsPy:
-
     def test_calculate_iou(self):
         assert round(calculate_iou(box1, box2), 3) == 0.019
 

--- a/tests/ut/test_lanms_py.py
+++ b/tests/ut/test_lanms_py.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from mindocr.postprocess.nms_py.lanms_py import calculate_iou, weighted_merge, standard_nms, lanms_win
+from mindocr.postprocess.nms_py.lanms_py import calculate_iou, weighted_merge, standard_nms, merge_quadrangle_n9
 
 box1 = np.array([0, 0, 0, 20, 10, 20, 10, 0, 0.8])
 box2 = np.array([8, 10, 8, 50, 30, 50, 30, 10, 0.7])
@@ -21,4 +21,4 @@ class TestLanmsPy:
 
     def test_lanms(self):
         expect_result = np.array([[8.611, 10, 8.611, 56.11, 30, 56.11, 30, 10, 1.8], [0, 0, 0, 20, 10, 20, 10, 0, 0.8]])
-        assert np.allclose(lanms_win([box1, box2, box3]), expect_result, 1e-2)
+        assert np.allclose(merge_quadrangle_n9([box1, box2, box3]), expect_result, 1e-2)

--- a/tests/ut/test_lanms_py.py
+++ b/tests/ut/test_lanms_py.py
@@ -1,0 +1,24 @@
+import numpy as np
+
+from mindocr.postprocess.nms_py.lanms_py import calculate_iou, weighted_merge, standard_nms, lanms_win
+
+box1 = np.array([0, 0, 0, 20, 10, 20, 10, 0, 0.8])
+box2 = np.array([8, 10, 8, 50, 30, 50, 30, 10, 0.7])
+box3 = np.array([9, 10, 9, 60, 30, 60, 30, 10, 1.1])
+
+
+class TestLanmsPy:
+
+    def test_calculate_iou(self):
+        assert round(calculate_iou(box1, box2), 3) == 0.019
+
+    def test_weighted_merge(self):
+        expect_result = np.array([3.733, 4.667, 3.733, 34, 19.333, 34, 19.333, 4.666, 1.5])
+        assert np.allclose(weighted_merge(box1, box2), expect_result, rtol=1e-2) is True
+
+    def test_standard_nms(self):
+        assert np.allclose(standard_nms([box2, box3], 0.5), box3, 1e-5)
+
+    def test_lanms(self):
+        expect_result = np.array([[8.611, 10, 8.611, 56.11, 30, 56.11, 30, 10, 1.8], [0, 0, 0, 20, 10, 20, 10, 0, 0.8]])
+        assert np.allclose(lanms_win([box1, box2, box3]), expect_result, 1e-2)

--- a/tools/dataset_converters/ic15.py
+++ b/tools/dataset_converters/ic15.py
@@ -36,7 +36,7 @@ class IC15_Converter(object):
 
     def _format_det_label(self, image_dir, label_dir, output_path):
         label_paths = sorted(glob.glob(os.path.join(label_dir, "*.txt")))
-        with open(output_path, "w") as out_file:
+        with open(output_path, "w", encoding="utf-8") as out_file:
             for label_fp in label_paths:
                 label_file_name = os.path.basename(label_fp)
                 img_path = os.path.join(image_dir, label_file_name[3:-4] + ".jpg")


### PR DESCRIPTION
Thank you for your contribution to the MindOCR repo.
Before submitting this PR, please make sure:

- [✔] You have read the [Contributing Guidelines on pull requests](https://github.com/mindspore-lab/mindcv/blob/main/CONTRIBUTING.md)
- [ ✔] Your code builds clean without any errors or warnings
- [ ✔] You are using approved terminology
- [✔ ] You have added unit tests

## Motivation

when I run 
```shell
pip install -r requirements.txt
```

![image](https://github.com/user-attachments/assets/0074d827-fcda-42f5-954d-bc72447cfcb4)


it is failed because of  the package **lanms**, the package does not support the windows environment very well. So I read the origin paper : https://arxiv.org/pdf/1704.03155v2 ,and write the algorithm in pure Python.

![image](https://github.com/user-attachments/assets/87f2b6e4-7a1f-4f89-b585-fcdb717859cf)

and I also remain the lanms package for systems except Windows, the pure python based lanms only works in Windows.

## Test Plan

- check the lanms is ignored when pip install in windows

![lanms被排除](https://github.com/user-attachments/assets/2396b5fa-1fe5-429d-b612-c85b0c07dd3a)

- check the eval result is same as origin

![my_lanms](https://github.com/user-attachments/assets/1cd80e24-326b-425c-afae-f11162d44871)

- check the eval result is same as the official version lanms

the author also provide a python version lanms( but is can not used by using pip install )

https://github.com/argman/EAST/blob/master/locality_aware_nms.py

![official_lanms](https://github.com/user-attachments/assets/371ffacb-9acc-48ab-b2b2-d5f62cbc85c6)


## Related Issues and PRs


