### PR TITLE
fix bug in ops.masked_fill by updating finfo func

### DIFF
--- a/configs/table/README.md
+++ b/configs/table/README.md
@@ -29,8 +29,8 @@ Through this approach, TableMaster is able to simultaneously learn and predict t
 
 | **Model**   | **Context**     | **Backbone**    | **Accuracy** | **Train T.** | **per step time** | **Throughput** | **Recipe**                            | Download                                                                                                 |
 |-------------|-----------------|-------------|--------------|--------------|-------------------|----------------|---------------------------------------|--------------------------------------------------------------------------------------------------------|
-| TableMaster | D910*x8-MS2.4-F | TableResNetExtra   | 77.47%       | 4218 s/epoch | 675 ms/step       | 15 img/s       | [yaml](table_master.yaml) | [ckpt](https://download-mindspore.osinfra.cn/toolkits/mindocr/tablemaster/table_master-78bf35bb.ckpt) |
-| TableMaster | D910*x8-MS2.3-G | TableResNetExtra   | 77.49%       | 1675 s/epoch | 268 ms/step       | 37 img/s | [yaml](table_master.yaml) | [ckpt](https://download-mindspore.osinfra.cn/toolkits/mindocr/tablemaster/table_master-78bf35bb.ckpt) |
+| TableMaster | D910*x8-MS2.4-F | TableResNetExtra   | 77.47%       | 4218 s/epoch | 675 ms/step       | 120 img/s      | [yaml](table_master.yaml) | [ckpt](https://download-mindspore.osinfra.cn/toolkits/mindocr/tablemaster/table_master-78bf35bb.ckpt) |
+| TableMaster | D910*x8-MS2.3-G | TableResNetExtra   | 77.49%       | 1675 s/epoch | 268 ms/step       | 296 img/s      | [yaml](table_master.yaml) | [ckpt](https://download-mindspore.osinfra.cn/toolkits/mindocr/tablemaster/table_master-78bf35bb.ckpt) |
 
 </div>
 

--- a/configs/table/README_CN.md
+++ b/configs/table/README_CN.md
@@ -26,10 +26,10 @@ TableMaster是一种用于表格识别的模型，其独特之处在于能够同
 ### PubTabNet
 <div align="center">
 
-| **模型**      | **环境配置**        | **骨干网络**    | **Accuracy** | **训练时间**     | **每步耗时**    | **FPS**  | **配置文件**                  | 模型权重下载                                                                                                     |
-|-------------|-----------------|-------------|--------------|--------------|-------------|----------|---------------------------|------------------------------------------------------------------------------------------------------------|
-| TableMaster | D910*x8-MS2.4-F | TableResNetExtra   | 77.47%       | 4218 s/epoch | 675 ms/step | 15 img/s | [yaml](table_master.yaml) | [ckpt](https://download-mindspore.osinfra.cn/toolkits/mindocr/tablemaster/table_master-78bf35bb.ckpt) |
-| TableMaster | D910*x8-MS2.3-G | TableResNetExtra   | 77.49%       | 1675 s/epoch | 268 ms/step | 37 img/s | [yaml](table_master.yaml) | [ckpt](https://download-mindspore.osinfra.cn/toolkits/mindocr/tablemaster/table_master-78bf35bb.ckpt) |
+| **模型**      | **环境配置**        | **骨干网络**    | **Accuracy** | **训练时间**     | **每步耗时**    | **FPS**   | **配置文件**                  | 模型权重下载                                                                                                     |
+|-------------|-----------------|-------------|--------------|--------------|-------------|-----------|---------------------------|------------------------------------------------------------------------------------------------------------|
+| TableMaster | D910*x8-MS2.4-F | TableResNetExtra   | 77.47%       | 4218 s/epoch | 675 ms/step | 120 img/s | [yaml](table_master.yaml) | [ckpt](https://download-mindspore.osinfra.cn/toolkits/mindocr/tablemaster/table_master-78bf35bb.ckpt) |
+| TableMaster | D910*x8-MS2.3-G | TableResNetExtra   | 77.49%       | 1675 s/epoch | 268 ms/step | 296 img/s | [yaml](table_master.yaml) | [ckpt](https://download-mindspore.osinfra.cn/toolkits/mindocr/tablemaster/table_master-78bf35bb.ckpt) |
 
 </div>
 

--- a/mindocr/models/backbones/transformer_common/layer.py
+++ b/mindocr/models/backbones/transformer_common/layer.py
@@ -11,9 +11,9 @@ from .activation import act_fn
 
 def finfo(dtype):
     if dtype == mstype.float32:
-        return np.finfo(np.float32).min
+        return Tensor(np.finfo(np.float32).min, mstype.float32)
     elif dtype == mstype.float16:
-        return np.finfo(np.float16).min
+        return Tensor(np.finfo(np.float16).min, mstype.float16)
     else:
         raise TypeError(f"For 'finfo', the input dtype should be float32 or float16, bug got {dtype}")
 


### PR DESCRIPTION
Thank you for your contribution to the MindOCR repo.
Before submitting this PR, please make sure:

- [ ] You have read the [Contributing Guidelines on pull requests](https://github.com/mindspore-lab/mindcv/blob/main/CONTRIBUTING.md)
- [ ] Your code builds clean without any errors or warnings
- [ ] You are using approved terminology
- [ ] You have added unit tests

## Motivation

While executing the evaluation for the vi_layoutxlm model, the following error occurred:
1. ser_vi_layoutxlm_xfund_zh.yaml 
-system.mode: 0
-model.backbone.use_float16: True
-model.head.use_float16: True
![image](https://github.com/user-attachments/assets/a1899186-118f-4ee6-8a93-f23c3c90ef96)
2. ser_vi_layoutxlm_xfund_zh.yaml 
-system.mode: 1
-model.backbone.use_float16: True
-model.head.use_float16: True
![image](https://github.com/user-attachments/assets/48b4b6b7-c3b9-4bc6-943e-9c8f3ddf10e6)

Or while infer the vi_layoutxlm model(by "tools/infer/text/predict_ser.py"), also occurs the following error:
![image](https://github.com/user-attachments/assets/e16dcc8d-19e2-4e22-bea5-354e43d33cec)

It need to change numpy.float16 to mindspore.Tensor type, so it need to update finfo func.
## Test Plan
First, use "python tools/eval.py --config configs/kie/vi_layoutxlm/ser_vi_layoutxlm_xfund_zh.yaml" for test:
1. ser_vi_layoutxlm_xfund_zh.yaml 
-system.mode: 0
-model.backbone.use_float16: True | False
-model.head.use_float16: True | False
![image](https://github.com/user-attachments/assets/87f19857-6463-45a5-bec9-2243d810065f)
![image](https://github.com/user-attachments/assets/69856ac9-e5a2-4ad6-b3be-72d774387607)

2. ser_vi_layoutxlm_xfund_zh.yaml 
-system.mode: 1
-model.backbone.use_float16: True | False
-model.head.use_float16: True | False
![image](https://github.com/user-attachments/assets/74c97c7e-cc94-410c-b554-6e4e17be146f)
![image](https://github.com/user-attachments/assets/e3398b2b-4516-4a68-8864-4a1fb747b0c6)

Second, use "python tools/infer/text/predict_ser.py --mode 1 --rec_algorithm CRNN_CH --image_dir  configs/kie/vi_layoutxlm/example.jpg" for test:
![image](https://github.com/user-attachments/assets/2f66c257-5263-46e9-89ad-9f72e21c6d66)

change mode: "python tools/infer/text/predict_ser.py --mode 0 --rec_algorithm CRNN_CH --image_dir  configs/kie/vi_layoutxlm/example.jpg"
![image](https://github.com/user-attachments/assets/c2e68ed7-73f8-41df-af06-0d3b0f228e02)
