### PR TITLE
use default ser ckpt in vi_layoutxlm_ser

### DIFF
--- a/mindocr/models/kie_layoutxlm.py
+++ b/mindocr/models/kie_layoutxlm.py
@@ -8,6 +8,9 @@ def _cfg(url="", **kwargs):
 
 
 default_cfgs = {
+    "layoutxlm": _cfg(
+        url="https://download.mindspore.cn/toolkits/mindocr/layoutxlm/ser_layoutxlm_base-a4ea148e.ckpt"
+    ),
     "vi_layoutxlm": _cfg(
         url="https://download.mindspore.cn/toolkits/mindocr/vi-layoutxlm/ser_vi_layoutxlm-f3c83585.ckpt"
     ),
@@ -65,19 +68,25 @@ def layoutxlm_ser(
     }
     model = KieNet(model_config)
     if pretrained:
-        default_cfg = default_cfgs["vi_layoutxlm"]
+        default_cfg = default_cfgs["layoutxlm"]
         load_pretrained(model, default_cfg)
 
     return model
 
 
 @register_model
-def vi_layoutxlm_ser(pretrained: bool = True, use_visual_backbone: bool = False, use_float16: bool = False, **kwargs):
+def vi_layoutxlm_ser(
+    pretrained: bool = True,
+    pretrained_backbone: bool = False,
+    use_visual_backbone: bool = False,
+    use_float16: bool = False,
+    **kwargs
+):
     model_config = {
         "type": "kie",
         "backbone": {
             "name": "layoutxlm",
-            "pretrained": pretrained,  # backbone pretrained
+            "pretrained": pretrained_backbone,  # backbone pretrained
             "use_visual_backbone": use_visual_backbone,
             "use_float16": use_float16,
         },
@@ -90,5 +99,8 @@ def vi_layoutxlm_ser(pretrained: bool = True, use_visual_backbone: bool = False,
         },
     }
     model = KieNet(model_config)
+    if pretrained:
+        default_cfg = default_cfgs["vi_layoutxlm"]
+        load_pretrained(model, default_cfg)
 
     return model


### PR DESCRIPTION
Thank you for your contribution to the MindOCR repo.
Before submitting this PR, please make sure:

- [ ] You have read the [Contributing Guidelines on pull requests](https://github.com/mindspore-lab/mindcv/blob/main/CONTRIBUTING.md)
- [ ] Your code builds clean without any errors or warnings
- [ ] You are using approved terminology
- [ ] You have added unit tests

## Motivation
1. update register_model: vi_layoutxlm_ser to use pretrain ckpt
2. fix bug by inferring ser in layoutxlm_ser: 
`[ERROR] ANALYZER(2921322,ffffa6185010,python):2024-12-30-08:59:24.113.844 [mindspore/ccsrc/pipeline/jit/ps/static_analysis/evaluator.cc:713] Run] Primitive: <StandardPrimEvaluator_list_getitem> infer failed, failed info: list_getitem evaluator index should be in range[-4, 4), but got 4.`

### Before Update（would not load ckpt in `mindocr/mindocr/models/kie_layoutxlm.py`）
1. infer with vi_layoutxlm: 
```python
python tools/infer/text/predict_ser.py --rec_algorithm CRNN_CH --det_algorithm DB_PPOCRv3 --image_dir configs/kie/vi_layoutxlm/example.jpg
```
![image](https://github.com/user-attachments/assets/3deae206-ef44-473f-8e98-bf98d1ee617f)

2. infer with layoutxlm, the following bugs have occurred:
```python
python tools/infer/text/predict_ser.py --rec_algorithm CRNN_CH --det_algorithm DB_PPOCRv3 --image_dir configs/kie/vi_layoutxlm/example.jpg --ser_algorithm LAYOUTXLM
```
![image](https://github.com/user-attachments/assets/8337647f-0b0a-47ea-b1e1-c9526f7104d0)


### After Update（use the best ckpt link）
1. infer with vi_layoutxlm:
```python
python tools/infer/text/predict_ser.py --rec_algorithm CRNN_CH --det_algorithm DB_PPOCRv3 --image_dir configs/kie/vi_layoutxlm/example.jpg
```
![image](https://github.com/user-attachments/assets/1fcbf2bc-5419-4901-8741-c62be18e1598)

2. infer with layoutxlm:
```python
python tools/infer/text/predict_ser.py --rec_algorithm CRNN_CH --det_algorithm DB_PPOCRv3 --image_dir configs/kie/vi_layoutxlm/example.jpg --ser_algorithm LAYOUTXLM
```
![image](https://github.com/user-attachments/assets/a6baf875-8fad-438d-a558-4365db5961c4)

3. eval with vi_layoutxlm:
```python
python tools/eval.py --config configs/kie/vi_layoutxlm/ser_vi_layoutxlm_xfund_zh.yaml
```
![image](https://github.com/user-attachments/assets/252ecfc9-b154-4d13-a68e-0b0594873b65)

4. eval with layoutxlm:
```python
python tools/eval.py --config configs/kie/layoutxlm/ser_layoutxlm_xfund_zh.yaml
```
![image](https://github.com/user-attachments/assets/7062d22d-6010-4826-94a6-a4b36ef80aff)

5. train with vi_layoutxlm:
```python
python tools/train.py --config configs/kie/vi_layoutxlm/ser_vi_layoutxlm_xfund_zh.yaml
```
![image](https://github.com/user-attachments/assets/4026dcab-f2b9-478c-913b-424a236b74f4)
![image](https://github.com/user-attachments/assets/d31bb985-1a7c-4385-b19e-5234399804ca)

6. train with layoutxlm:
```python
python tools/train.py --config configs/kie/layoutxlm/ser_layoutxlm_xfund_zh.yaml
```
![image](https://github.com/user-attachments/assets/48e3097a-2b63-44ea-97e5-d641dda39211)
![image](https://github.com/user-attachments/assets/721b1136-7138-4fe8-9d93-8b13211ae83b)

## Test Plan
test for 
```python
# download mindocr
git clone -b feat-update-kie-ckpt-link https://github.com/hongziqi/mindocr.git
# build mindocr wheel package and install mindocr
python setup.py bdist_wheel
pip install dist/mindocr-0.4.0-py3-none-any.whl

# infer with VI_LAYOUTXLM
python tools/infer/text/predict_ser.py --rec_algorithm CRNN_CH --det_algorithm DB_PPOCRv3 --image_dir configs/kie/vi_layoutxlm/example.jpg

# infer with LAYOUTXLM
python tools/infer/text/predict_ser.py --rec_algorithm CRNN_CH --det_algorithm DB_PPOCRv3 --image_dir configs/kie/vi_layoutxlm/example.jpg --ser_algorithm LAYOUTXLM

# download dataset
wget https://download.mindspore.cn/toolkits/mindocr/vi-layoutxlm/XFUND.tar && tar -xf XFUND.tar
# train or eval (need to update the path in yaml, please refer to the file: configs/kie/vi_layoutxlm/README_CN.md)
python tools/train.py(eval.py) --config configs/kie/vi_layoutxlm/ser_vi_layoutxlm_xfund_zh.yaml
python tools/train.py(eval.py) --config configs/kie/layoutxlm/ser_layoutxlm_xfund_zh.yaml
```
