### PR TITLE
Update lanms to lanms-nova

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ PyYAML>=6.0
 xml-python>=0.4.3
 packaging>=23.1
 Cython
-lanms>=1.0.2; python_version <= '3.10' and sys_platform == 'linux'
+lanms-nova>=1.0.3; sys_platform == 'linux'
 sentencepiece>=0.1.99
 huggingface_hub>=0.16.4
 seqeval>=1.2.2


### PR DESCRIPTION
Thank you for your contribution to the MindOCR repo.
Before submitting this PR, please make sure:

- [ ] You have read the [Contributing Guidelines on pull requests](https://github.com/mindspore-lab/mindcv/blob/main/CONTRIBUTING.md)
- [ ] Your code builds clean without any errors or warnings
- [ ] You are using approved terminology
- [ ] You have added unit tests

## Motivation

Due to the frequent installation failures caused by lanms, update lanms to the more compile-stable lanms-nova in the requirements.
Unlike lanms, lanms-nova also supports Python 3.11 compilation, thus removing the original Python version restrictions for installing lanms.

## Test Plan

(How should this PR be tested? Do you require special setup to run the test or repro the fixed bug?)

## Related Issues and PRs

(Is this PR part of a group of changes? Link the other relevant PRs and Issues here. Use https://help.github.com/en/articles/closing-issues-using-keywords for help on GitHub syntax)
