### PR TITLE
fix synthText dataset convert

### DIFF
--- a/tools/dataset_converters/synthtext.py
+++ b/tools/dataset_converters/synthtext.py
@@ -143,7 +143,7 @@ class SYNTHTEXT_Converter:
         wordBB, txt = zip(*data_list)
         for i in range(len(mat["wordBB"][0])):
             mat["wordBB"][0][i] = wordBB[i]
-        mat["txt"] = np.array(txt).reshape(1, -1)
+        mat["txt"] = np.array(txt, dtype=object).reshape(1, -1)
 
         data_list = defaultdict(list)
         for image, polys, texts in zip(mat["imnames"][0], mat["wordBB"][0], mat["txt"][0]):
@@ -168,8 +168,8 @@ class SYNTHTEXT_Converter:
             )
 
         images, labels = zip(*data_list)
-        images = iter(itertools.chain(*images))
-        labels = iter(itertools.chain(*labels))
+        images = list(itertools.chain(*images))
+        labels = list(itertools.chain(*labels))
 
         print("Creating the LMDB dataset.")
         create_lmdb_dataset(images, labels, output_path=output_path)


### PR DESCRIPTION
Thank you for your contribution to the MindOCR repo.
Before submitting this PR, please make sure:

- [ ] You have read the [Contributing Guidelines on pull requests](https://github.com/mindspore-lab/mindcv/blob/main/CONTRIBUTING.md)
- [ ] Your code builds clean without any errors or warnings
- [ ] You are using approved terminology
- [ ] You have added unit tests

## Motivation

1. Due to different lengths of sublists in the array, add dtype=object in np.array to adapt the change from Numpy 1.22.
2. Since itertools.chain does not have len() method, change iter to list.


## Test Plan

(How should this PR be tested? Do you require special setup to run the test or repro the fixed bug?)

## Related Issues and PRs

(Is this PR part of a group of changes? Link the other relevant PRs and Issues here. Use https://help.github.com/en/articles/closing-issues-using-keywords for help on GitHub syntax)
